### PR TITLE
feat: add slots and metrics to turn panel

### DIFF
--- a/app.js
+++ b/app.js
@@ -31,9 +31,18 @@
     });
   }
 
+  let bluePanelRefs = null;
+  function updateBluePanel(state) {
+    if (!bluePanelRefs) return;
+    bluePanelRefs.pv.textContent = `${state.pv}/10`;
+    bluePanelRefs.pa.textContent = `${state.pa}`;
+    bluePanelRefs.pm.textContent = `${state.pm}`;
+  }
+
   function updateHudAll(blueState, redState) {
     updateHudSide('.measure-left', blueState);
     updateHudSide('.measure-right', redState);
+    updateBluePanel(blueState);
   }
 
   function computeReachable(start, pm, isAllowed) {
@@ -261,12 +270,30 @@
       }
     }
 
-    // Painel e botão de passar vez
+    // Painel inferior com slots, métricas e botão de passar vez
     const panel = document.createElement('div');
     panel.className = 'turn-panel';
+
+    const slots = document.createElement('div');
+    slots.className = 'slots';
+    for (let i = 0; i < 4; i++) {
+      const slot = document.createElement('div');
+      slot.className = 'slot';
+      slots.appendChild(slot);
+    }
+
+    const metrics = document.createElement('div');
+    metrics.className = 'metrics';
+    metrics.innerHTML = `
+      <div class="metric"><span class="k">PV</span><span class="v pv"></span></div>
+      <div class="metric"><span class="k">PA</span><span class="v pa"></span></div>
+      <div class="metric"><span class="k">PM</span><span class="v pm"></span></div>
+    `;
+
     const passBtn = document.createElement('button');
     passBtn.className = 'pass-btn';
     passBtn.type = 'button';
+
     const timerEl = document.createElement('span');
     timerEl.className = 'turn-timer';
 
@@ -275,9 +302,18 @@
       timerEl.textContent = `(${Math.max(0, timeLeft)}s)`;
     }
 
+    panel.appendChild(slots);
+    panel.appendChild(metrics);
     panel.appendChild(passBtn);
     panel.appendChild(timerEl);
     document.body.appendChild(panel);
+
+    bluePanelRefs = {
+      pv: metrics.querySelector('.pv'),
+      pa: metrics.querySelector('.pa'),
+      pm: metrics.querySelector('.pm'),
+    };
+    updateBluePanel(units.blue);
 
     function passTurn() {
       // Reseta PM do que terminou

--- a/style.css
+++ b/style.css
@@ -182,18 +182,44 @@ body {
 /* Painel de turno */
 .turn-panel {
   position: fixed;
-  right: 16px;
-  bottom: 16px;
-  display: inline-grid;
-  grid-auto-flow: column;
-  gap: 10px;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  display: flex;
   align-items: center;
+  gap: 16px;
   background: rgba(17,24,39,.8);
   color: #fff;
-  padding: 10px 12px;
-  border-radius: 10px;
-  box-shadow: 0 8px 20px rgba(0,0,0,.35);
+  padding: 10px 16px;
+  box-shadow: 0 -4px 20px rgba(0,0,0,.35);
   z-index: 10;
+}
+
+.turn-panel .slots {
+  flex: 1;
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  gap: 8px;
+}
+
+.turn-panel .slot {
+  border: 2px dashed rgba(255,255,255,.3);
+  border-radius: 6px;
+  min-height: 50px;
+}
+
+.turn-panel .metrics {
+  flex: 1;
+  display: flex;
+  justify-content: center;
+  gap: 12px;
+}
+
+.turn-panel .metrics .metric {
+  display: inline-grid;
+  grid-auto-flow: column;
+  grid-auto-columns: max-content;
+  gap: 6px;
 }
 
 .turn-panel .pass-btn {
@@ -205,6 +231,7 @@ body {
   padding: 10px 14px;
   border-radius: 8px;
   cursor: pointer;
+  margin-left: auto;
 }
 
 .turn-panel .pass-btn:hover { filter: brightness(1.05); }
@@ -212,6 +239,7 @@ body {
 .turn-panel .turn-timer {
   font-weight: 700;
   opacity: .9;
+  margin-left: 8px;
 }
 
 /* Face simplificada: cantos com Naipe/A */


### PR DESCRIPTION
## Summary
- add bottom panel with slots, metrics and pass-turn button
- update HUD to sync blue unit values with bottom panel
- expand styles so turn panel spans bottom and aligns new elements

## Testing
- `node --check app.js`
- `npm test` *(fails: enoent could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a016f70bb8832ea11643c0a1123e35