### PR TITLE
feat: add enemy stats tooltip

### DIFF
--- a/app.js
+++ b/app.js
@@ -167,6 +167,12 @@
     // Instancia ambas as unidades
     units.blue.el = createUnitEl('blue');
     units.red.el = createUnitEl('red');
+
+    const enemyTooltip = document.createElement('div');
+    enemyTooltip.className = 'enemy-tooltip';
+    enemyTooltip.style.display = 'none';
+    document.body.appendChild(enemyTooltip);
+
     mountUnit(units.blue);
     mountUnit(units.red);
 
@@ -207,6 +213,18 @@
     units.red.el.addEventListener('mouseenter', () => {
       if (activeId !== 'red') return;
       showReachableFor(units.red);
+    });
+
+    units.red.el.addEventListener('mouseenter', ev => {
+      enemyTooltip.innerHTML = `PV: ${units.red.pv}<br>PA: ${units.red.pa}<br>PM: ${units.red.pm}`;
+      const rect = units.red.el.getBoundingClientRect();
+      enemyTooltip.style.left = `${rect.right + 8 + window.scrollX}px`;
+      enemyTooltip.style.top = `${rect.top + window.scrollY}px`;
+      enemyTooltip.style.display = 'block';
+    });
+
+    units.red.el.addEventListener('mouseleave', () => {
+      enemyTooltip.style.display = 'none';
     });
 
     // Clique para mover para uma célula alcançável

--- a/style.css
+++ b/style.css
@@ -179,6 +179,29 @@ body {
 .unit.unit-red { background: rgba(220, 38, 38, 0.9); }
 .unit.is-active { box-shadow: 0 0 0 3px #fff, 0 0 0 6px rgba(16,185,129,.9); }
 
+/* Tooltip de inimigo */
+.enemy-tooltip {
+  position: absolute;
+  background: rgba(17,24,39,.9);
+  color: #fff;
+  padding: 6px 8px;
+  border-radius: 6px;
+  font-size: 14px;
+  pointer-events: none;
+  display: none;
+  z-index: 20;
+}
+
+.enemy-tooltip::after {
+  content: "";
+  position: absolute;
+  top: 100%;
+  left: 10px;
+  border-width: 6px;
+  border-style: solid;
+  border-color: rgba(17,24,39,.9) transparent transparent transparent;
+}
+
 /* Painel de turno */
 .turn-panel {
   position: fixed;


### PR DESCRIPTION
## Summary
- add tooltip for red unit showing current PV, PA, PM
- style tooltip with dark bubble and arrow

## Testing
- `npm test` *(fails: ENOENT could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a016f4a408832ebbda7a54a05c4c1a