### PR TITLE
Add footer slots layout

### DIFF
--- a/index.html
+++ b/index.html
@@ -68,6 +68,12 @@
             <div class="card back blue"></div>
           </div>
         </div>
+        <div class="footer">
+          <div class="footer-slot"></div>
+          <div class="footer-slot"></div>
+          <div class="footer-slot"></div>
+          <div class="footer-slot"></div>
+        </div>
       </div>
     </div>
     <script src="./app.js"></script>

--- a/style.css
+++ b/style.css
@@ -120,7 +120,7 @@ body {
 /* Tabuleiro */
 .board {
   position: absolute;
-  inset: 6% 12%;
+  inset: 6% 12% 24%;
   display: grid;
   place-items: center;
 }
@@ -135,6 +135,24 @@ body {
   height: 100%;
   width: auto;
   aspect-ratio: var(--cols) / var(--rows); /* garante células quadradas */
+}
+
+.footer {
+  position: absolute;
+  left: 12%;
+  right: 12%;
+  bottom: 6%;
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  gap: clamp(8px, 1.6vw, 16px);
+}
+
+.footer-slot {
+  aspect-ratio: 1 / 1;
+  width: 100%;
+  border-radius: 10px;
+  outline: 2px dashed var(--card-border);
+  background: var(--board-bg);
 }
 
 .card,


### PR DESCRIPTION
## Summary
- add footer with four uniform slots
- reserve space in board for taller footer and style slots as squares

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a01bb476d8832e8f870142aeb44cdf