### PR TITLE
Add footer status bar with dynamic player metrics

### DIFF
--- a/app.js
+++ b/app.js
@@ -16,25 +16,6 @@
     return row >= 0 && row < ROWS && col >= 0 && col < COLS;
   }
 
-  function updateHudSide(containerSelector, state) {
-    const container = document.querySelector(containerSelector);
-    if (!container) return;
-    const metrics = container.querySelectorAll('.metric');
-    metrics.forEach(metric => {
-      const key = metric.querySelector('.k');
-      const val = metric.querySelector('.v');
-      if (!key || !val) return;
-      const k = key.textContent.trim();
-      if (k === 'PV') val.textContent = `${state.pv}/10`;
-      if (k === 'PM') val.textContent = `${state.pm}`;
-      if (k === 'PA') val.textContent = `${state.pa}`;
-    });
-  }
-
-  function updateHudAll(blueState, redState) {
-    updateHudSide('.measure-left', blueState);
-    updateHudSide('.measure-right', redState);
-  }
 
   function computeReachable(start, pm, isAllowed) {
     const deltas = [
@@ -101,6 +82,16 @@
     const grid = document.querySelector('.grid');
     if (!grid) return;
 
+    const pvBar = document.querySelector('.status-bar .pv');
+    const pmBar = document.querySelector('.status-bar .pm');
+    const paBar = document.querySelector('.status-bar .pa');
+
+    function updateStatusBar(state) {
+      if (pvBar) pvBar.textContent = `${state.pv}/10`;
+      if (pmBar) pmBar.textContent = `${state.pm}`;
+      if (paBar) paBar.textContent = `${state.pa}`;
+    }
+
     const cards = Array.from(grid.children);
     // Indexa as células e define data attributes
     cards.forEach((el, i) => {
@@ -146,8 +137,42 @@
     let activeId = 'blue';
     const getActive = () => units[activeId];
     const getInactive = () => units[activeId === 'blue' ? 'red' : 'blue'];
+    const playerStatusEl = document.getElementById('player-status');
+    const opponentHoverEl = document.createElement('div');
+    opponentHoverEl.className = 'opponent-hover';
+    document.body.appendChild(opponentHoverEl);
 
-    updateHudAll(units.blue, units.red);
+    function renderPlayerStatus() {
+      const active = getActive();
+      if (!playerStatusEl) return;
+      playerStatusEl.innerHTML =
+        `<div class="metric"><span class="k">PV</span><span class="v">${active.pv}/10</span></div>` +
+        `<div class="metric"><span class="k">PM</span><span class="v">${active.pm}</span></div>` +
+        `<div class="metric"><span class="k">PA</span><span class="v">${active.pa}</span></div>`;
+      playerStatusEl.classList.toggle('blue', active.id === 'blue');
+      playerStatusEl.classList.toggle('red', active.id === 'red');
+      updateStatusBar(active);
+    }
+
+    function showOpponentStatus(unit) {
+      if (!opponentHoverEl || !unit.el) return;
+      opponentHoverEl.innerHTML =
+        `<div class="metric"><span class="k">PV</span><span class="v">${unit.pv}/10</span></div>` +
+        `<div class="metric"><span class="k">PM</span><span class="v">${unit.pm}</span></div>` +
+        `<div class="metric"><span class="k">PA</span><span class="v">${unit.pa}</span></div>`;
+      opponentHoverEl.classList.toggle('blue', unit.id === 'blue');
+      opponentHoverEl.classList.toggle('red', unit.id === 'red');
+      const rect = unit.el.getBoundingClientRect();
+      opponentHoverEl.style.left = `${rect.left + rect.width / 2}px`;
+      opponentHoverEl.style.top = `${rect.top}px`;
+      opponentHoverEl.style.display = 'grid';
+    }
+
+    function hideOpponentStatus() {
+      opponentHoverEl.style.display = 'none';
+    }
+
+    renderPlayerStatus();
 
     // Cria o elemento da unidade
     function createUnitEl(id) {
@@ -199,14 +224,26 @@
       }
     }
 
-    // Exibe alcance quando o mouse entra na unidade ativa
+    // Exibe alcance da unidade ativa e status do oponente no hover
     units.blue.el.addEventListener('mouseenter', () => {
-      if (activeId !== 'blue') return;
-      showReachableFor(units.blue);
+      if (activeId === 'blue') {
+        showReachableFor(units.blue);
+      } else {
+        showOpponentStatus(units.blue);
+      }
+    });
+    units.blue.el.addEventListener('mouseleave', () => {
+      if (activeId !== 'blue') hideOpponentStatus();
     });
     units.red.el.addEventListener('mouseenter', () => {
-      if (activeId !== 'red') return;
-      showReachableFor(units.red);
+      if (activeId === 'red') {
+        showReachableFor(units.red);
+      } else {
+        showOpponentStatus(units.red);
+      }
+    });
+    units.red.el.addEventListener('mouseleave', () => {
+      if (activeId !== 'red') hideOpponentStatus();
     });
 
     // Clique para mover para uma célula alcançável
@@ -230,7 +267,7 @@
       active.pm -= cost;
       active.pos = { row: r, col: c };
       mountUnit(active);
-      updateHudAll(units.blue, units.red);
+      renderPlayerStatus();
 
       // Atualiza destaque conforme PM restante
       showReachableFor(active);
@@ -288,7 +325,8 @@
       activeId = activeId === 'blue' ? 'red' : 'blue';
       reflectActiveStyles();
       clearReachable();
-      updateHudAll(units.blue, units.red);
+      renderPlayerStatus();
+      hideOpponentStatus();
       startTurnTimer();
     }
 

--- a/index.html
+++ b/index.html
@@ -11,20 +11,12 @@
       <div class="layout" aria-label="tabuleiro">
         <div class="measure measure-left">
           <div class="line" aria-hidden="true"></div>
-          <div class="label">
-            <div class="metric"><span class="k">PV</span><span class="v">10/10</span></div>
-            <div class="metric"><span class="k">PM</span><span class="v">3</span></div>
-            <div class="metric"><span class="k">PA</span><span class="v">3</span></div>
-          </div>
+          <div class="label"></div>
         </div>
 
         <div class="measure measure-right">
           <div class="line" aria-hidden="true"></div>
-          <div class="label">
-            <div class="metric"><span class="k">PV</span><span class="v">10/10</span></div>
-            <div class="metric"><span class="k">PM</span><span class="v">3</span></div>
-            <div class="metric"><span class="k">PA</span><span class="v">3</span></div>
-          </div>
+          <div class="label"></div>
         </div>
 
         <div class="midline" aria-hidden="true"></div>
@@ -68,8 +60,24 @@
             <div class="card back blue"></div>
           </div>
         </div>
+        <div class="footer">
+          <div class="footer-slot"></div>
+          <div class="footer-slot"></div>
+          <div class="footer-slot"></div>
+          <div class="footer-slot"></div>
+        </div>
+      </div>
+      <div id="player-status" class="player-status">
+        <div class="metric"><span class="k">PV</span><span class="v">10/10</span></div>
+        <div class="metric"><span class="k">PM</span><span class="v">3</span></div>
+        <div class="metric"><span class="k">PA</span><span class="v">3</span></div>
       </div>
     </div>
+    <footer class="status-bar">
+      <div class="status-item"><span class="label">PV</span><span class="value pv">10/10</span></div>
+      <div class="status-item"><span class="label">PM</span><span class="value pm">3</span></div>
+      <div class="status-item"><span class="label">PA</span><span class="value pa">3</span></div>
+    </footer>
     <script src="./app.js"></script>
   </body>
   </html>

--- a/style.css
+++ b/style.css
@@ -120,7 +120,7 @@ body {
 /* Tabuleiro */
 .board {
   position: absolute;
-  inset: 6% 12%;
+  inset: 6% 12% 24%;
   display: grid;
   place-items: center;
 }
@@ -135,6 +135,24 @@ body {
   height: 100%;
   width: auto;
   aspect-ratio: var(--cols) / var(--rows); /* garante células quadradas */
+}
+
+.footer {
+  position: absolute;
+  left: 12%;
+  right: 12%;
+  bottom: 6%;
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  gap: clamp(8px, 1.6vw, 16px);
+}
+
+.footer-slot {
+  aspect-ratio: 1 / 1;
+  width: 100%;
+  border-radius: 10px;
+  outline: 2px dashed var(--card-border);
+  background: var(--board-bg);
 }
 
 .card,
@@ -213,6 +231,59 @@ body {
   font-weight: 700;
   opacity: .9;
 }
+
+/* Barra de status do jogador */
+.player-status {
+  position: fixed;
+  left: 50%;
+  bottom: 0;
+  transform: translateX(-50%);
+  display: inline-grid;
+  grid-auto-flow: column;
+  gap: 12px;
+  background: rgba(17,24,39,.85);
+  color: #fff;
+  padding: 8px 12px;
+  border-radius: 10px 10px 0 0;
+  box-shadow: 0 8px 20px rgba(0,0,0,.35);
+  font-size: clamp(14px, 1.8vw, 18px);
+  z-index: 10;
+}
+
+.player-status.blue { color: var(--blue); }
+.player-status.red { color: var(--red); }
+
+.player-status .metric,
+.opponent-hover .metric {
+  display: inline-grid;
+  grid-auto-flow: column;
+  gap: 8px;
+  line-height: 1.1;
+}
+
+.player-status .metric .k,
+.opponent-hover .metric .k { font-weight: 800; }
+
+.player-status .metric .v,
+.opponent-hover .metric .v { font-weight: 700; }
+
+/* Tooltip de status do adversário */
+.opponent-hover {
+  position: absolute;
+  display: none;
+  background: rgba(17,24,39,.9);
+  color: #fff;
+  padding: 6px 8px;
+  border-radius: 6px;
+  box-shadow: 0 4px 10px rgba(0,0,0,.3);
+  transform: translate(-50%, -110%);
+  font-size: clamp(12px, 1.5vw, 16px);
+  pointer-events: none;
+  z-index: 20;
+}
+
+.opponent-hover.blue { color: var(--blue); }
+.opponent-hover.red { color: var(--red); }
 
 /* Face simplificada: cantos com Naipe/A */
 .card.face::before,
@@ -318,6 +389,37 @@ body {
 /* Ajuste do conteúdo central real */
 .card.face > .center::before {
   content: var(--pip);
+}
+
+/* Barra de status fixa no rodapé */
+.status-bar {
+  position: fixed;
+  left: 0;
+  bottom: 0;
+  width: 100%;
+  height: 48px;
+  background: var(--black);
+  color: var(--card);
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  gap: 24px;
+  z-index: 10;
+}
+
+.status-bar .status-item {
+  display: flex;
+  gap: 4px;
+  font-weight: 700;
+  font-size: clamp(14px, 2vw, 18px);
+}
+
+.status-bar .label {
+  font-weight: 800;
+}
+
+.status-bar .value {
+  font-weight: 700;
 }
 
 


### PR DESCRIPTION
## Summary
- resolve merge conflicts with latest main branch
- keep footer status bar markup and styling intact
- update player status rendering to drive footer values after moves and turn changes

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a01bd84680832ea8a5a073c193c988