### PR TITLE
Highlight reachable cards with green overlay

### DIFF
--- a/style.css
+++ b/style.css
@@ -163,6 +163,7 @@ body {
 .card.reachable {
   outline: 3px solid rgba(16, 185, 129, 0.85);
   outline-offset: -3px;
+  background-color: rgba(16, 185, 129, 0.25);
 }
 
 /* Diferenciar unidades e turno ativo */


### PR DESCRIPTION
## Summary
- Add light green background to `.card.reachable` so reachable cells show a soft overlay while keeping outline

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a0e38c3458832ebfc28f804c6cf396