### PR TITLE
Simplify HUD by removing side panels

### DIFF
--- a/app.js
+++ b/app.js
@@ -16,33 +16,12 @@
     return row >= 0 && row < ROWS && col >= 0 && col < COLS;
   }
 
-  function updateHudSide(containerSelector, state) {
-    const container = document.querySelector(containerSelector);
-    if (!container) return;
-    const metrics = container.querySelectorAll('.metric');
-    metrics.forEach(metric => {
-      const key = metric.querySelector('.k');
-      const val = metric.querySelector('.v');
-      if (!key || !val) return;
-      const k = key.textContent.trim();
-      if (k === 'PV') val.textContent = `${state.pv}/10`;
-      if (k === 'PM') val.textContent = `${state.pm}`;
-      if (k === 'PA') val.textContent = `${state.pa}`;
-    });
-  }
-
   let bluePanelRefs = null;
   function updateBluePanel(state) {
     if (!bluePanelRefs) return;
     bluePanelRefs.pv.textContent = `${state.pv}/10`;
     bluePanelRefs.pa.textContent = `${state.pa}`;
     bluePanelRefs.pm.textContent = `${state.pm}`;
-  }
-
-  function updateHudAll(blueState, redState) {
-    updateHudSide('.measure-left', blueState);
-    updateHudSide('.measure-right', redState);
-    updateBluePanel(blueState);
   }
 
   function computeReachable(start, pm, isAllowed) {
@@ -156,7 +135,7 @@
     const getActive = () => units[activeId];
     const getInactive = () => units[activeId === 'blue' ? 'red' : 'blue'];
 
-    updateHudAll(units.blue, units.red);
+    updateBluePanel(units.blue);
 
     // Cria o elemento da unidade
     function createUnitEl(id) {
@@ -257,7 +236,7 @@
       active.pm -= cost;
       active.pos = { row: r, col: c };
       mountUnit(active);
-      updateHudAll(units.blue, units.red);
+      updateBluePanel(units.blue);
 
       // Atualiza destaque conforme PM restante
       showReachableFor(active);
@@ -342,7 +321,7 @@
       activeId = activeId === 'blue' ? 'red' : 'blue';
       reflectActiveStyles();
       clearReachable();
-      updateHudAll(units.blue, units.red);
+      updateBluePanel(units.blue);
       startTurnTimer();
     }
 

--- a/index.html
+++ b/index.html
@@ -9,22 +9,6 @@
   <body>
     <div class="page">
       <div class="layout" aria-label="tabuleiro">
-        <div class="measure measure-left">
-          <div class="label">
-            <div class="metric"><span class="k">PV</span><span class="v">10/10</span></div>
-            <div class="metric"><span class="k">PM</span><span class="v">3</span></div>
-            <div class="metric"><span class="k">PA</span><span class="v">3</span></div>
-          </div>
-        </div>
-
-        <div class="measure measure-right">
-          <div class="label">
-            <div class="metric"><span class="k">PV</span><span class="v">10/10</span></div>
-            <div class="metric"><span class="k">PM</span><span class="v">3</span></div>
-            <div class="metric"><span class="k">PA</span><span class="v">3</span></div>
-          </div>
-        </div>
-
         <div class="midline" aria-hidden="true"></div>
 
         <div class="board">


### PR DESCRIPTION
## Summary
- Remove left/right HUD containers from HTML
- Drop `updateHudSide` and `updateHudAll` in favor of `updateBluePanel`
- Update movement and turn logic to refresh only the blue panel

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a0e3324834832e8c66f4ad79df2930