### PR TITLE
refactor: modularize board logic

### DIFF
--- a/index.html
+++ b/index.html
@@ -52,7 +52,7 @@
         </div>
       </div>
     </div>
-    <script src="./app.js"></script>
+    <script type="module" src="js/main.js"></script>
   </body>
   </html>
 

--- a/js/board-utils.js
+++ b/js/board-utils.js
@@ -1,0 +1,14 @@
+export const COLS = 4;
+export const ROWS = 6;
+
+export function indexToRowCol(index) {
+  return { row: Math.floor(index / COLS), col: index % COLS };
+}
+
+export function rowColToIndex(row, col) {
+  return row * COLS + col;
+}
+
+export function isInside(row, col) {
+  return row >= 0 && row < ROWS && col >= 0 && col < COLS;
+}

--- a/js/main.js
+++ b/js/main.js
@@ -1,0 +1,69 @@
+import { COLS, ROWS, indexToRowCol, rowColToIndex } from './board-utils.js';
+import { computeReachable, buildPath } from './pathfinding.js';
+import { units, initUnits, getActive, showReachableFor, mountUnit } from './units.js';
+import { initUI, updateBluePanel, initEnemyTooltip } from './ui.js';
+
+document.addEventListener('DOMContentLoaded', () => {
+  const grid = document.querySelector('.grid');
+  if (!grid) return;
+
+  const cards = Array.from(grid.children);
+  cards.forEach((el, i) => {
+    const { row, col } = indexToRowCol(i);
+    el.dataset.row = String(row);
+    el.dataset.col = String(col);
+    el.dataset.color = el.classList.contains('blue') ? 'blue' : 'red';
+  });
+
+  const isBlue = (r, c) => {
+    const idx = rowColToIndex(r, c);
+    const el = cards[idx];
+    return el && el.dataset.color === 'blue';
+  };
+  const isRed = (r, c) => {
+    const idx = rowColToIndex(r, c);
+    const el = cards[idx];
+    return el && el.dataset.color === 'red';
+  };
+
+  initUnits(cards, isBlue, isRed);
+  initEnemyTooltip();
+  initUI();
+
+  units.blue.el.addEventListener('mouseenter', () => {
+    if (getActive().id !== 'blue') return;
+    showReachableFor(units.blue);
+  });
+  units.red.el.addEventListener('mouseenter', () => {
+    if (getActive().id !== 'red') return;
+    showReachableFor(units.red);
+  });
+
+  grid.addEventListener('click', (ev) => {
+    const target = ev.target;
+    if (!(target instanceof HTMLElement)) return;
+    const cell = target.closest('.card');
+    if (!cell) return;
+    if (!cell.classList.contains('reachable')) return;
+
+    const r = Number(cell.dataset.row);
+    const c = Number(cell.dataset.col);
+    const active = getActive();
+    const dist = computeReachable(active.pos, active.pm, active.allow);
+    const path = buildPath(active.pos, { row: r, col: c }, dist, active.allow);
+    if (!path) return;
+
+    const cost = dist[r][c];
+    if (!Number.isFinite(cost) || cost <= 0 || cost > active.pm) return;
+
+    active.pm -= cost;
+    active.pos = { row: r, col: c };
+    mountUnit(active);
+    updateBluePanel(units.blue);
+
+    // Atualiza destaque conforme PM restante
+    showReachableFor(active);
+  });
+
+  console.log('[Tabuleiro] Unidades inicializadas', units);
+});

--- a/js/pathfinding.js
+++ b/js/pathfinding.js
@@ -1,0 +1,62 @@
+import { COLS, ROWS, isInside } from './board-utils.js';
+
+export function computeReachable(start, pm, isAllowed) {
+  const deltas = [
+    [1, 0],
+    [-1, 0],
+    [0, 1],
+    [0, -1],
+  ];
+  const dist = Array.from({ length: ROWS }, () => Array(COLS).fill(Infinity));
+  const queue = [];
+  dist[start.row][start.col] = 0;
+  queue.push(start);
+
+  while (queue.length) {
+    const cur = queue.shift();
+    for (const [dr, dc] of deltas) {
+      const nr = cur.row + dr;
+      const nc = cur.col + dc;
+      if (!isInside(nr, nc)) continue;
+      if (!isAllowed(nr, nc)) continue; // respeita cor do lado
+      const nd = dist[cur.row][cur.col] + 1;
+      if (nd <= pm && nd < dist[nr][nc]) {
+        dist[nr][nc] = nd;
+        queue.push({ row: nr, col: nc });
+      }
+    }
+  }
+
+  return dist; // contém distâncias; Infinity significa inalcançável
+}
+
+export function buildPath(from, to, dist, isAllowed) {
+  // retrocede por vizinhos com distância decrescente
+  const path = [];
+  let cur = { ...to };
+  if (!Number.isFinite(dist[to.row][to.col])) return null;
+
+  while (!(cur.row === from.row && cur.col === from.col)) {
+    path.push(cur);
+    const neighbors = [
+      { row: cur.row + 1, col: cur.col },
+      { row: cur.row - 1, col: cur.col },
+      { row: cur.row, col: cur.col + 1 },
+      { row: cur.row, col: cur.col - 1 },
+    ];
+    let moved = false;
+    for (const n of neighbors) {
+      if (!isInside(n.row, n.col)) continue;
+      if (!isAllowed(n.row, n.col)) continue;
+      if (dist[n.row][n.col] === dist[cur.row][cur.col] - 1) {
+        cur = n;
+        moved = true;
+        break;
+      }
+    }
+    if (!moved) return null;
+  }
+  path.push(from);
+  path.reverse();
+  return path;
+}

--- a/js/ui.js
+++ b/js/ui.js
@@ -1,0 +1,115 @@
+import { units, getActive, setActiveId, clearReachable } from './units.js';
+
+let bluePanelRefs = null;
+
+export function updateBluePanel(state) {
+  if (!bluePanelRefs) return;
+  bluePanelRefs.pv.textContent = `${state.pv}/10`;
+  bluePanelRefs.pa.textContent = `${state.pa}`;
+  bluePanelRefs.pm.textContent = `${state.pm}`;
+}
+
+const TURN_SECONDS = 30;
+let timeLeft = TURN_SECONDS;
+let intervalId = null;
+let passBtn = null;
+let timerEl = null;
+
+function updatePassButton() {
+  passBtn.textContent = 'Passar Vez';
+  timerEl.textContent = `(${Math.max(0, timeLeft)}s)`;
+}
+
+export function startTurnTimer() {
+  stopTurnTimer();
+  timeLeft = TURN_SECONDS;
+  updatePassButton();
+  intervalId = setInterval(() => {
+    timeLeft -= 1;
+    updatePassButton();
+    if (timeLeft <= 0) {
+      passTurn();
+    }
+  }, 1000);
+}
+
+export function stopTurnTimer() {
+  if (intervalId) {
+    clearInterval(intervalId);
+    intervalId = null;
+  }
+}
+
+function passTurn() {
+  const finished = getActive();
+  finished.pm = 3;
+  const next = finished.id === 'blue' ? 'red' : 'blue';
+  setActiveId(next);
+  clearReachable();
+  updateBluePanel(units.blue);
+  startTurnTimer();
+}
+
+export function initUI() {
+  const panel = document.createElement('div');
+  panel.className = 'turn-panel';
+
+  const slots = document.createElement('div');
+  slots.className = 'slots';
+  for (let i = 0; i < 4; i++) {
+    const slot = document.createElement('div');
+    slot.className = 'slot';
+    slots.appendChild(slot);
+  }
+
+  const metrics = document.createElement('div');
+  metrics.className = 'metrics';
+  metrics.innerHTML = `
+      <div class="metric"><span class="k">PV</span><span class="v pv"></span></div>
+      <div class="metric"><span class="k">PA</span><span class="v pa"></span></div>
+      <div class="metric"><span class="k">PM</span><span class="v pm"></span></div>
+    `;
+
+  passBtn = document.createElement('button');
+  passBtn.className = 'pass-btn';
+  passBtn.type = 'button';
+
+  timerEl = document.createElement('span');
+  timerEl.className = 'turn-timer';
+
+  panel.appendChild(slots);
+  panel.appendChild(metrics);
+  panel.appendChild(passBtn);
+  panel.appendChild(timerEl);
+  document.body.appendChild(panel);
+
+  bluePanelRefs = {
+    pv: metrics.querySelector('.pv'),
+    pa: metrics.querySelector('.pa'),
+    pm: metrics.querySelector('.pm'),
+  };
+  updateBluePanel(units.blue);
+
+  passBtn.addEventListener('click', passTurn);
+  startTurnTimer();
+}
+
+export function initEnemyTooltip() {
+  const enemyTooltip = document.createElement('div');
+  enemyTooltip.className = 'enemy-tooltip';
+  enemyTooltip.style.display = 'none';
+  document.body.appendChild(enemyTooltip);
+
+  const enemy = units.red;
+  enemy.el.addEventListener('mouseenter', () => {
+    enemyTooltip.innerHTML = `PV: ${enemy.pv}<br>PA: ${enemy.pa}<br>PM: ${enemy.pm}`;
+    const rect = enemy.el.getBoundingClientRect();
+    enemyTooltip.style.left = `${rect.right + 8 + window.scrollX}px`;
+    enemyTooltip.style.top = `${rect.top + window.scrollY}px`;
+    enemyTooltip.style.display = 'block';
+  });
+
+  enemy.el.addEventListener('mouseleave', () => {
+    enemyTooltip.style.display = 'none';
+  });
+}

--- a/js/units.js
+++ b/js/units.js
@@ -1,0 +1,86 @@
+import { ROWS, COLS, rowColToIndex } from './board-utils.js';
+import { computeReachable } from './pathfinding.js';
+
+let cards = [];
+
+export const units = {
+  blue: {
+    id: 'blue',
+    pv: 10,
+    pm: 3,
+    pa: 3,
+    pos: { row: 5, col: 3 },
+    allow: null,
+    el: null,
+  },
+  red: {
+    id: 'red',
+    pv: 10,
+    pm: 3,
+    pa: 3,
+    pos: { row: 0, col: 0 },
+    allow: null,
+    el: null,
+  },
+};
+
+let activeId = 'blue';
+export const getActive = () => units[activeId];
+export const getInactive = () => units[activeId === 'blue' ? 'red' : 'blue'];
+export function setActiveId(id) {
+  activeId = id;
+  reflectActiveStyles();
+}
+
+export function initUnits(cardEls, isBlue, isRed) {
+  cards = cardEls;
+  units.blue.allow = isBlue;
+  units.red.allow = isRed;
+  units.blue.el = createUnitEl('blue');
+  units.red.el = createUnitEl('red');
+  mountUnit(units.blue);
+  mountUnit(units.red);
+  reflectActiveStyles();
+}
+
+export function createUnitEl(id) {
+  const el = document.createElement('div');
+  el.className = `unit unit-${id}`;
+  el.title = 'Unidade (hover p/ alcance, clique em verde p/ mover)';
+  return el;
+}
+
+export function mountUnit(unit) {
+  const idx = rowColToIndex(unit.pos.row, unit.pos.col);
+  const host = cards[idx];
+  if (!host) return;
+  host.appendChild(unit.el);
+}
+
+export function reflectActiveStyles() {
+  Object.values(units).forEach(u => {
+    if (!u.el) return;
+    if (u.id === activeId) u.el.classList.add('is-active');
+    else u.el.classList.remove('is-active');
+  });
+}
+
+export function clearReachable() {
+  cards.forEach(c => c.classList.remove('reachable'));
+}
+
+export function showReachableFor(unit) {
+  clearReachable();
+  if (unit.pm <= 0) return;
+  const dist = computeReachable(unit.pos, unit.pm, unit.allow);
+  for (let r = 0; r < ROWS; r++) {
+    for (let c = 0; c < COLS; c++) {
+      if (!unit.allow(r, c)) continue;
+      const d = dist[r][c];
+      if (Number.isFinite(d) && d > 0 && d <= unit.pm) {
+        const idx = rowColToIndex(r, c);
+        cards[idx].classList.add('reachable');
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- split board helpers into js/board-utils.js
- extract pathfinding logic into js/pathfinding.js
- modularize units handling and UI into dedicated modules
- wire everything through js/main.js and update HTML to load it

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a0e86033f0832eacea4e6eb4ce0f82