### PR TITLE
chore: initialize npm and add jest config

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,16 @@
+{
+  "name": "tabuleiro",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "tabuleiro",
+      "version": "1.0.0",
+      "license": "ISC",
+      "devDependencies": {
+        "jest": "^29.0.0"
+      }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "tabuleiro",
+  "version": "1.0.0",
+  "description": "Protótipo de jogo de tabuleiro com cartas e turnos, escrito em HTML, CSS e JavaScript.",
+  "main": "app.js",
+  "scripts": {
+    "test": "jest"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "type": "module",
+  "devDependencies": {
+    "jest": "^29.0.0"
+  }
+}


### PR DESCRIPTION
## Summary
- set up npm project configuration with ES module support
- add Jest test script and declare Jest as a dev dependency

## Testing
- `npm test` *(fails: jest not found after install attempt failed with 403 from registry)*

------
https://chatgpt.com/codex/tasks/task_e_68a0eb7a17cc832ebaaddabf64cf979f