### PR TITLE
Fix turn panel layout

### DIFF
--- a/css/turn-panel.css
+++ b/css/turn-panel.css
@@ -6,29 +6,30 @@
   bottom: 0;
   display: flex;
   align-items: center;
+  justify-content: center;
   gap: 16px;
   background: rgba(17,24,39,.8);
   color: #fff;
   padding: 10px 16px;
+  height: 80px;
   box-shadow: 0 -4px 20px rgba(0,0,0,.35);
   z-index: 10;
 }
 
 .turn-panel .slots {
-  flex: 1;
   display: grid;
-  grid-template-columns: repeat(4, 1fr);
+  grid-template-columns: repeat(4, 64px);
   gap: 8px;
 }
 
 .turn-panel .slot {
   border: 2px dashed rgba(255,255,255,.3);
   border-radius: 6px;
-  aspect-ratio: 1 / 1;
+  width: 64px;
+  height: 64px;
 }
 
 .turn-panel .metrics {
-  flex: 1;
   display: flex;
   justify-content: center;
   gap: 12px;
@@ -50,7 +51,6 @@
   padding: 10px 14px;
   border-radius: 8px;
   cursor: pointer;
-  margin-left: auto;
 }
 
 .turn-panel .pass-btn:hover { filter: brightness(1.05); }


### PR DESCRIPTION
## Summary
- Center turn panel contents and remove auto margin from pass button
- Give slots fixed dimensions and grid columns
- Set panel to a constant height for consistent layout

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a0f08d889c832eb8f71be4ecb3a16a