### PR TITLE
Refactor layout to use flex container

### DIFF
--- a/css/layout.css
+++ b/css/layout.css
@@ -1,7 +1,8 @@
 .page {
-  min-height: 100dvh;
-  display: grid;
-  place-items: center;
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
   padding: 24px;
 }
 
@@ -9,6 +10,7 @@
   position: relative;
   width: min(840px, 90vw);
   aspect-ratio: 1 / 1; /* canvas quadrado para simplificar */
+  flex: 1;
 }
 
 /* Rótulos laterais */

--- a/css/turn-panel.css
+++ b/css/turn-panel.css
@@ -1,9 +1,5 @@
 /* Painel de turno */
 .turn-panel {
-  position: fixed;
-  left: 0;
-  right: 0;
-  bottom: 0;
   display: flex;
   align-items: center;
   gap: 16px;
@@ -11,7 +7,8 @@
   color: #fff;
   padding: 10px 16px;
   box-shadow: 0 -4px 20px rgba(0,0,0,.35);
-  z-index: 10;
+  margin-top: auto;
+  width: 100%;
 }
 
 .turn-panel .slots {

--- a/js/ui.js
+++ b/js/ui.js
@@ -81,7 +81,10 @@ export function initUI() {
   panel.appendChild(metrics);
   panel.appendChild(passBtn);
   panel.appendChild(timerEl);
-  document.body.appendChild(panel);
+  const page = document.querySelector('.page');
+  if (page) {
+    page.appendChild(panel);
+  }
 
   bluePanelRefs = {
     pv: metrics.querySelector('.pv'),


### PR DESCRIPTION
## Summary
- append turn panel inside main `.page` container
- switch `.page` layout to flex column and allow board area to grow
- remove fixed positioning from turn panel and anchor it with flex

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a0f08c3a78832eb8f71aa0b842e7c1