### PR TITLE
Adiciona mapa de fases e persistência de progresso

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Protótipo de jogo de tabuleiro com cartas e turnos, escrito em HTML, CSS e Java
 ## Como executar
 
 1. Não há dependências.
-2. Basta abrir `index.html` em um navegador moderno.
+2. Abra `map.html` em um navegador moderno. O botão **Jogar** leva ao tabuleiro em `index.html`.
 
 ## Sobre o jogo
 
@@ -15,6 +15,8 @@ Protótipo de jogo de tabuleiro com cartas e turnos, escrito em HTML, CSS e Java
 
 ## Estrutura
 
+- `map.html`: mapa de fases com indicação do estágio atual.
+- `js/map.js`: renderização do mapa e controle do estágio.
 - `index.html`: marcação principal do tabuleiro.
 - Diretório `css/`: estilos da interface.
 - `js/main.js`: lógica de jogo e controle de turnos.

--- a/js/map.js
+++ b/js/map.js
@@ -1,0 +1,58 @@
+const path = [
+  { x: 80, y: 20 },
+  { x: 80, y: 120 },
+  { x: 80, y: 220 },
+  { x: 80, y: 320 },
+  { x: 80, y: 420 }
+];
+
+const stageKey = 'stage';
+const playedKey = 'played';
+
+let stage = Number(localStorage.getItem(stageKey));
+if (Number.isNaN(stage)) {
+  stage = 0;
+}
+
+if (localStorage.getItem(playedKey)) {
+  stage += 1;
+  localStorage.removeItem(playedKey);
+}
+
+localStorage.setItem(stageKey, stage);
+
+const container = document.getElementById('map');
+
+path.forEach((node, idx) => {
+  const el = document.createElement('div');
+  el.className = 'node' + (idx === stage ? ' current' : '');
+  el.style.left = `${node.x}px`;
+  el.style.top = `${node.y}px`;
+  container.appendChild(el);
+
+  if (idx > 0) {
+    const prev = path[idx - 1];
+    const conn = document.createElement('div');
+    conn.className = 'connection';
+    conn.style.left = `${prev.x + 10}px`;
+    conn.style.top = `${prev.y + 10}px`;
+    conn.style.height = `${node.y - prev.y}px`;
+    container.appendChild(conn);
+  }
+});
+
+const playBtn = document.getElementById('play');
+const current = path[stage];
+if (current) {
+  playBtn.style.left = `${current.x + 40}px`;
+  playBtn.style.top = `${current.y}px`;
+} else {
+  playBtn.disabled = true;
+  playBtn.style.display = 'none';
+}
+
+playBtn.addEventListener('click', () => {
+  localStorage.setItem(stageKey, stage);
+  localStorage.setItem(playedKey, 'true');
+  window.location.href = 'index.html';
+});

--- a/map.html
+++ b/map.html
@@ -1,0 +1,41 @@
+<!doctype html>
+<html lang="pt-BR">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Mapa</title>
+    <link rel="stylesheet" href="./css/base.css" />
+    <style>
+      .map-container {
+        position: relative;
+        margin: 40px auto;
+        width: 200px;
+        height: 600px;
+      }
+      .node {
+        position: absolute;
+        width: 20px;
+        height: 20px;
+        border-radius: 50%;
+        background: #888;
+      }
+      .node.current {
+        background: #4caf50;
+      }
+      .connection {
+        position: absolute;
+        width: 2px;
+        background: #000;
+      }
+      #play {
+        position: absolute;
+      }
+    </style>
+  </head>
+  <body>
+    <div class="map-container" id="map">
+      <button id="play">Jogar</button>
+    </div>
+    <script type="module" src="js/map.js"></script>
+  </body>
+</html>

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "tabuleiro",
   "version": "1.0.0",
   "description": "Protótipo de jogo de tabuleiro com cartas e turnos, escrito em HTML, CSS e JavaScript.",
-  "main": "app.js",
+  "main": "map.html",
   "scripts": {
     "test": "node --experimental-vm-modules node_modules/jest/bin/jest.js"
   },


### PR DESCRIPTION
## Resumo
- cria `map.html` com representação vertical das fases
- implementa `js/map.js` para renderizar nós e conexões e destacar estágio atual
- adiciona botão **Jogar** que leva ao tabuleiro e persiste progresso no `localStorage`
- define `map.html` como ponto de entrada no `package.json` e atualiza README

## Testes
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a0f6780c00832e8e8c4fbce8b4d41f