### PR TITLE
Adicionar carta Soco ao painel de turno

### DIFF
--- a/js/ui.js
+++ b/js/ui.js
@@ -62,6 +62,27 @@ export function initUI() {
     slots.appendChild(slot);
   }
 
+  const socoSlot = slots.children[0];
+  const cardSoco = document.createElement('div');
+  cardSoco.className = 'card-soco';
+  cardSoco.textContent = '👊';
+  const atk = document.createElement('span');
+  atk.className = 'atk';
+  atk.textContent = '2';
+  cardSoco.appendChild(atk);
+  socoSlot.appendChild(cardSoco);
+  let socoSelecionado = false;
+  socoSlot.addEventListener('click', () => {
+    if (getActive().id !== 'blue') return;
+    socoSelecionado = !socoSelecionado;
+    socoSlot.classList.toggle('is-selected', socoSelecionado);
+    if (socoSelecionado) {
+      showSocoAlcance();
+    } else {
+      clearSocoAlcance();
+    }
+  });
+
   const metrics = document.createElement('div');
   metrics.className = 'metrics';
   metrics.innerHTML = `


### PR DESCRIPTION
## Summary
- Incluir carta "Soco" com ícone e dano no primeiro slot do painel de turno
- Controlar estado de seleção da carta e alternar classe `is-selected`
- Acionar `showSocoAlcance` e `clearSocoAlcance` ao selecionar/desselecionar

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a162d70660832e966d2c66c6691bb6