### PR TITLE
Add attack range utilities

### DIFF
--- a/js/ui.js
+++ b/js/ui.js
@@ -3,20 +3,17 @@ import {
   getActive,
   setActiveId,
   clearReachable,
-  showReachableFor,
+  showSocoAlcance as showSocoAlcanceUnits,
+  clearSocoAlcance as clearSocoAlcanceUnits,
 } from './units.js';
 
 function showSocoAlcance() {
   const active = getActive();
-  showReachableFor({
-    pos: active.pos,
-    pm: 1,
-    allow: () => true,
-  });
+  showSocoAlcanceUnits(active);
 }
 
 function clearSocoAlcance() {
-  clearReachable();
+  clearSocoAlcanceUnits();
 }
 
 let bluePanelRefs = null;

--- a/js/units.js
+++ b/js/units.js
@@ -1,4 +1,4 @@
-import { ROWS, COLS, rowColToIndex } from './board-utils.js';
+import { ROWS, COLS, rowColToIndex, isInside } from './board-utils.js';
 import { computeReachable } from './pathfinding.js';
 
 let cards = [];
@@ -83,4 +83,27 @@ export function showReachableFor(unit) {
       }
     }
   }
+}
+
+export function clearSocoAlcance() {
+  cards.forEach(c => c.classList.remove('attackable'));
+}
+
+export function showSocoAlcance(unit) {
+  clearSocoAlcance();
+  const { row, col } = unit.pos;
+  const deltas = [
+    [-1, 0],
+    [1, 0],
+    [0, -1],
+    [0, 1],
+  ];
+  deltas.forEach(([dr, dc]) => {
+    const r = row + dr;
+    const c = col + dc;
+    if (!isInside(r, c)) return;
+    const idx = rowColToIndex(r, c);
+    const card = cards[idx];
+    if (card) card.classList.add('attackable');
+  });
 }


### PR DESCRIPTION
## Summary
- highlight melee attack range around units
- expose UI helpers to show or clear attackable cells

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a16925a718832e910fa7e43db0a2d6