### PR TITLE
Estiliza painel de turno e alcance de soco

### DIFF
--- a/css/cards.css
+++ b/css/cards.css
@@ -36,6 +36,12 @@
   background-color: rgba(16, 185, 129, 0.25);
 }
 
+.card.attackable {
+  outline: 3px solid rgba(59,130,246,.85);
+  outline-offset: -3px;
+  background-color: rgba(59,130,246,.25);
+}
+
 /* Diferenciar unidades e turno ativo */
 .unit.unit-blue { background: rgba(29, 78, 216, 0.9); }
 .unit.unit-red { background: rgba(220, 38, 38, 0.9); }

--- a/css/turn-panel.css
+++ b/css/turn-panel.css
@@ -26,6 +26,26 @@
   height: 64px;
 }
 
+.slot .card-soco {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 32px;
+  position: relative;
+}
+
+.slot .card-soco .atk {
+  position: absolute;
+  top: 2px;
+  right: 4px;
+  font-size: 14px;
+  font-weight: 700;
+}
+
+.slot.is-selected {
+  outline: 3px solid rgba(59,130,246,.9);
+}
+
 .turn-panel .metrics {
   display: flex;
   justify-content: center;


### PR DESCRIPTION
## Summary
- style the punch card slot with centered layout and selection outline
- highlight cards in punch range with blue outline background

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a16cfaef64832eb2e7ef5bce7a1247