### PR TITLE
Animate unit movement with cost indicator

### DIFF
--- a/css/cards.css
+++ b/css/cards.css
@@ -175,3 +175,27 @@
   content: var(--pip);
 }
 
+.float-text {
+  position: absolute;
+  top: -10px;
+  left: 50%;
+  transform: translate(-50%, -100%);
+  animation: fadeUp 0.6s ease-out forwards;
+  pointer-events: none;
+}
+
+.float-text.pm {
+  color: #16a34a;
+}
+
+@keyframes fadeUp {
+  from {
+    opacity: 1;
+    transform: translate(-50%, -100%) translateY(0);
+  }
+  to {
+    opacity: 0;
+    transform: translate(-50%, -100%) translateY(-20px);
+  }
+}
+

--- a/js/main.js
+++ b/js/main.js
@@ -8,8 +8,18 @@ import {
   showReachableFor,
   mountUnit,
   clearSocoAlcance,
+  showFloatingText,
 } from './units.js';
 import { initUI, updateBluePanel, initEnemyTooltip, uiState } from './ui.js';
+
+async function moveUnitAlongPath(unit, path, cost) {
+  for (const step of path.slice(1)) {
+    unit.pos = step;
+    mountUnit(unit);
+    await new Promise(r => setTimeout(r, 150));
+  }
+  showFloatingText(unit.el, `-${cost}`, 'pm');
+}
 
 document.addEventListener('DOMContentLoaded', () => {
   const grid = document.querySelector('.grid');
@@ -47,7 +57,7 @@ document.addEventListener('DOMContentLoaded', () => {
     showReachableFor(units.red);
   });
 
-  grid.addEventListener('click', (ev) => {
+  grid.addEventListener('click', async (ev) => {
     const target = ev.target;
     if (!(target instanceof HTMLElement)) return;
     const cell = target.closest('.card');
@@ -82,8 +92,7 @@ document.addEventListener('DOMContentLoaded', () => {
     if (!Number.isFinite(cost) || cost <= 0 || cost > active.pm) return;
 
     active.pm -= cost;
-    active.pos = { row: r, col: c };
-    mountUnit(active);
+    await moveUnitAlongPath(active, path, cost);
     updateBluePanel(units.blue);
 
     // Atualiza destaque conforme PM restante

--- a/js/units.js
+++ b/js/units.js
@@ -107,3 +107,17 @@ export function showSocoAlcance(unit) {
     if (card) card.classList.add('attackable');
   });
 }
+
+export function showFloatingText(el, text, className = '') {
+  const span = document.createElement('span');
+  span.className = `float-text${className ? ` ${className}` : ''}`;
+  span.textContent = text;
+  el.appendChild(span);
+  span.addEventListener(
+    'animationend',
+    () => {
+      span.remove();
+    },
+    { once: true }
+  );
+}


### PR DESCRIPTION
## Summary
- animate units along their paths and display PM cost floating text
- add utility for floating text and related CSS styles

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a1720f3bf4832eb9f5ac535dc206c3