### PR TITLE
feat: animate attack with shake and floating text

### DIFF
--- a/css/cards.css
+++ b/css/cards.css
@@ -29,6 +29,10 @@
   cursor: pointer;
 }
 
+.unit.shake {
+  animation: shake 0.3s;
+}
+
 /* Alcance (células verdes) */
 .card.reachable {
   outline: 3px solid rgba(16, 185, 129, 0.85);
@@ -186,6 +190,26 @@
 
 .float-text.pm {
   color: #16a34a;
+}
+
+.float-text.pa {
+  color: #3b82f6;
+}
+
+.float-text.pv {
+  color: #dc2626;
+}
+
+@keyframes shake {
+  0%, 100% {
+    transform: translate(-50%, -50%);
+  }
+  25% {
+    transform: translate(calc(-50% + 4px), -50%);
+  }
+  75% {
+    transform: translate(calc(-50% - 4px), -50%);
+  }
 }
 
 @keyframes fadeUp {

--- a/js/main.js
+++ b/js/main.js
@@ -21,6 +21,15 @@ async function moveUnitAlongPath(unit, path, cost) {
   showFloatingText(unit.el, `-${cost}`, 'pm');
 }
 
+function animateAttack(attacker, defender) {
+  defender.el.classList.add('shake');
+  setTimeout(() => {
+    defender.el.classList.remove('shake');
+  }, 300);
+  showFloatingText(attacker.el, '-3', 'pa');
+  showFloatingText(defender.el, '-2', 'pv');
+}
+
 document.addEventListener('DOMContentLoaded', () => {
   const grid = document.querySelector('.grid');
   if (!grid) return;
@@ -69,6 +78,7 @@ document.addEventListener('DOMContentLoaded', () => {
       const c = Number(cell.dataset.col);
       const enemy = getInactive();
       if (enemy.pos.row === r && enemy.pos.col === c && active.pa >= 3) {
+        animateAttack(active, enemy);
         active.pa -= 3;
         enemy.pv -= 2;
         updateBluePanel(units.blue);


### PR DESCRIPTION
## Summary
- add animateAttack to shake defender and display PA and PV floating text
- call attack animation when punch is executed
- style shake animation and colored floating text

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a17545eea4832e889f366dc8a10011