### PR TITLE
Generalize unit animations to work for any active side

### DIFF
--- a/css/cards.css
+++ b/css/cards.css
@@ -188,6 +188,14 @@
   color: #16a34a;
 }
 
+.float-text.pa {
+  color: #f59e0b;
+}
+
+.float-text.pv {
+  color: #dc2626;
+}
+
 @keyframes fadeUp {
   from {
     opacity: 1;

--- a/js/main.js
+++ b/js/main.js
@@ -18,7 +18,13 @@ async function moveUnitAlongPath(unit, path, cost) {
     mountUnit(unit);
     await new Promise(r => setTimeout(r, 150));
   }
-  showFloatingText(unit.el, `-${cost}`, 'pm');
+  showFloatingText(unit, `-${cost}`, 'pm');
+}
+
+async function animateAttack(attacker, defender, paCost, damage) {
+  showFloatingText(attacker, `-${paCost}`, 'pa');
+  showFloatingText(defender, `-${damage}`, 'pv');
+  await new Promise(r => setTimeout(r, 600));
 }
 
 document.addEventListener('DOMContentLoaded', () => {
@@ -48,13 +54,11 @@ document.addEventListener('DOMContentLoaded', () => {
   initEnemyTooltip();
   initUI();
 
-  units.blue.el.addEventListener('mouseenter', () => {
-    if (getActive().id !== 'blue') return;
-    showReachableFor(units.blue);
-  });
-  units.red.el.addEventListener('mouseenter', () => {
-    if (getActive().id !== 'red') return;
-    showReachableFor(units.red);
+  Object.values(units).forEach(u => {
+    u.el.addEventListener('mouseenter', () => {
+      if (getActive().id !== u.id) return;
+      showReachableFor(u);
+    });
   });
 
   grid.addEventListener('click', async (ev) => {
@@ -69,8 +73,11 @@ document.addEventListener('DOMContentLoaded', () => {
       const c = Number(cell.dataset.col);
       const enemy = getInactive();
       if (enemy.pos.row === r && enemy.pos.col === c && active.pa >= 3) {
-        active.pa -= 3;
-        enemy.pv -= 2;
+        const paCost = 3;
+        const damage = 2;
+        active.pa -= paCost;
+        enemy.pv -= damage;
+        await animateAttack(active, enemy, paCost, damage);
         updateBluePanel(units.blue);
         mountUnit(enemy);
       }

--- a/js/units.js
+++ b/js/units.js
@@ -108,7 +108,9 @@ export function showSocoAlcance(unit) {
   });
 }
 
-export function showFloatingText(el, text, className = '') {
+export function showFloatingText(target, text, className = '') {
+  const el = target?.el ?? target;
+  if (!el) return;
   const span = document.createElement('span');
   span.className = `float-text${className ? ` ${className}` : ''}`;
   span.textContent = text;


### PR DESCRIPTION
## Summary
- Support floating text for any unit and add attack animation helper
- Animate movement and attacks for both sides via `getActive`/`getInactive`
- Add PA and PV floating text styles

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a175169608832eb4c1f8004319e3b0