### PR TITLE
fix: merge duplicate attack animation definition

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -22,18 +22,13 @@ async function moveUnitAlongPath(unit, path, cost) {
 }
 
 async function animateAttack(attacker, defender, paCost, damage) {
-  showFloatingText(attacker, `-${paCost}`, 'pa');
-  showFloatingText(defender, `-${damage}`, 'pv');
-  await new Promise(r => setTimeout(r, 600));
-}
-
-function animateAttack(attacker, defender) {
   defender.el.classList.add('shake');
   setTimeout(() => {
     defender.el.classList.remove('shake');
   }, 300);
-  showFloatingText(attacker.el, '-3', 'pa');
-  showFloatingText(defender.el, '-2', 'pv');
+  showFloatingText(attacker, `-${paCost}`, 'pa');
+  showFloatingText(defender, `-${damage}`, 'pv');
+  await new Promise(r => setTimeout(r, 600));
 }
 
 document.addEventListener('DOMContentLoaded', () => {


### PR DESCRIPTION
## Summary
- merge attack animation logic into a single `animateAttack` function to avoid duplicate identifier

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a17913a750832e8550c52f18a115ea