### PR TITLE
Reset PA on turn pass

### DIFF
--- a/js/ui.js
+++ b/js/ui.js
@@ -37,6 +37,7 @@ let passBtn = null;
 let timerEl = null;
 
 function updatePassButton() {
+  if (!passBtn || !timerEl) return;
   passBtn.textContent = 'Passar Vez';
   timerEl.textContent = `(${Math.max(0, timeLeft)}s)`;
 }
@@ -61,9 +62,10 @@ export function stopTurnTimer() {
   }
 }
 
-function passTurn() {
+export function passTurn() {
   const finished = getActive();
   finished.pm = 3;
+  finished.pa = 6;
   const next = finished.id === 'blue' ? 'red' : 'blue';
   setActiveId(next);
   clearReachable();

--- a/tests/ui.test.js
+++ b/tests/ui.test.js
@@ -1,0 +1,23 @@
+import { passTurn, stopTurnTimer } from '../js/ui.js';
+import { units, setActiveId } from '../js/units.js';
+
+describe('passTurn', () => {
+  afterEach(() => {
+    stopTurnTimer();
+  });
+
+  test('refills PA for the unit that ended its turn', () => {
+    setActiveId('blue');
+    units.blue.pa = 1;
+    passTurn();
+    expect(units.blue.pa).toBe(6);
+  });
+
+  test('refills PA for the opposing unit as well', () => {
+    setActiveId('red');
+    units.red.pa = 2;
+    passTurn();
+    expect(units.red.pa).toBe(6);
+  });
+});
+


### PR DESCRIPTION
## Summary
- Refill action points when a unit ends its turn just like movement points
- Guard pass button updates when UI elements are missing
- Add tests covering PA restoration for both units

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a17d8d8084832eb0a38447ca5cdbe0