### PR TITLE
Inverte caminho do mapa de fases

### DIFF
--- a/js/map.js
+++ b/js/map.js
@@ -1,9 +1,9 @@
 const path = [
-  { x: 80, y: 20 },
-  { x: 80, y: 120 },
-  { x: 80, y: 220 },
-  { x: 80, y: 320 },
   { x: 80, y: 420 },
+  { x: 80, y: 320 },
+  { x: 80, y: 220 },
+  { x: 80, y: 120 },
+  { x: 80, y: 20 },
 ];
 
 const stageKey = 'stage';
@@ -37,8 +37,8 @@ path.forEach((node, idx) => {
     const conn = document.createElement('div');
     conn.className = 'map-connection';
     conn.style.left = `${prev.x + 10}px`;
-    conn.style.top = `${prev.y + 12}px`;
-    conn.style.height = `${node.y - prev.y}px`;
+    conn.style.top = `${Math.min(prev.y, node.y) + 12}px`;
+    conn.style.height = `${Math.abs(node.y - prev.y)}px`;
     container.appendChild(conn);
   }
 });


### PR DESCRIPTION
## Summary
- Inverte ordem das fases do mapa para começar de baixo para cima
- Ajusta cálculo das conexões do caminho para lidar com posições invertidas

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a182c00888832e9e1b457b3e4daf25