### PR TITLE
Add overlay and popup UI helpers

### DIFF
--- a/css/overlay.css
+++ b/css/overlay.css
@@ -1,0 +1,65 @@
+.overlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  background: rgba(0, 0, 0, 0.7);
+  color: #fff;
+  z-index: 1000;
+  animation: fade-in 0.3s;
+}
+
+.popup-container {
+  position: fixed;
+  top: 1rem;
+  right: 1rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  z-index: 1000;
+}
+
+.popup {
+  background: var(--black);
+  color: #fff;
+  padding: 0.5rem 1rem;
+  border-radius: 4px;
+  animation: slide-in 0.3s;
+}
+
+.fade-out {
+  animation: fade-out 0.3s forwards;
+}
+
+@keyframes fade-in {
+  from {
+    opacity: 0;
+  }
+  to {
+    opacity: 1;
+  }
+}
+
+@keyframes fade-out {
+  from {
+    opacity: 1;
+  }
+  to {
+    opacity: 0;
+  }
+}
+
+@keyframes slide-in {
+  from {
+    transform: translateY(-10px);
+    opacity: 0;
+  }
+  to {
+    transform: translateY(0);
+    opacity: 1;
+  }
+}

--- a/index.html
+++ b/index.html
@@ -9,6 +9,7 @@
       <link rel="stylesheet" href="./css/cards.css" />
       <link rel="stylesheet" href="./css/turn-panel.css" />
       <link rel="stylesheet" href="./css/map.css" />
+      <link rel="stylesheet" href="./css/overlay.css" />
   </head>
   <body>
     <div id="map-screen">

--- a/js/overlay.js
+++ b/js/overlay.js
@@ -1,0 +1,41 @@
+export function showOverlay(msg, { duration = 2000 } = {}) {
+  const el = document.createElement('div');
+  el.className = 'overlay';
+  el.textContent = msg;
+  document.body.appendChild(el);
+
+  setTimeout(() => {
+    el.classList.add('fade-out');
+    setTimeout(() => {
+      el.remove();
+    }, 300);
+  }, duration);
+
+  return el;
+}
+
+export function showPopup(msg, { duration = 2000 } = {}) {
+  let container = document.querySelector('.popup-container');
+  if (!container) {
+    container = document.createElement('div');
+    container.className = 'popup-container';
+    document.body.appendChild(container);
+  }
+
+  const popup = document.createElement('div');
+  popup.className = 'popup';
+  popup.textContent = msg;
+  container.appendChild(popup);
+
+  setTimeout(() => {
+    popup.classList.add('fade-out');
+    setTimeout(() => {
+      popup.remove();
+      if (container.childElementCount === 0) {
+        container.remove();
+      }
+    }, 300);
+  }, duration);
+
+  return popup;
+}

--- a/js/ui.js
+++ b/js/ui.js
@@ -6,6 +6,7 @@ import {
   showSocoAlcance as showSocoAlcanceUnits,
   clearSocoAlcance as clearSocoAlcanceUnits,
 } from './units.js';
+import { showOverlay, showPopup } from './overlay.js';
 
 export const uiState = {
   socoSlot: null,
@@ -160,3 +161,5 @@ export function initEnemyTooltip() {
     enemyTooltip.style.display = 'none';
   });
 }
+
+export { showOverlay, showPopup };

--- a/tests/overlay.test.js
+++ b/tests/overlay.test.js
@@ -1,0 +1,34 @@
+import { jest } from '@jest/globals';
+import { showOverlay, showPopup } from '../js/ui.js';
+
+describe('overlay helpers', () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+  });
+
+  afterEach(() => {
+    jest.runOnlyPendingTimers();
+    jest.useRealTimers();
+    document.body.innerHTML = '';
+  });
+
+  test('showOverlay adds and removes element', () => {
+    showOverlay('Olá', { duration: 100 });
+    expect(document.querySelector('.overlay')).not.toBeNull();
+
+    jest.advanceTimersByTime(100);
+    jest.advanceTimersByTime(300);
+    expect(document.querySelector('.overlay')).toBeNull();
+  });
+
+  test('showPopup adds and removes element', () => {
+    showPopup('Oi', { duration: 100 });
+    expect(document.querySelector('.popup')).not.toBeNull();
+    expect(document.querySelector('.popup-container')).not.toBeNull();
+
+    jest.advanceTimersByTime(100);
+    jest.advanceTimersByTime(300);
+    expect(document.querySelector('.popup')).toBeNull();
+    expect(document.querySelector('.popup-container')).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary
- add temporary overlay and popup helpers
- style overlay and popups and include stylesheet
- expose helpers via ui.js and cover with tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a187e203c0832e84d3aee2209ca11b