### PR TITLE
Display popup at turn start

### DIFF
--- a/js/ui.js
+++ b/js/ui.js
@@ -69,6 +69,10 @@ export function passTurn() {
   finished.pa = 6;
   const next = finished.id === 'blue' ? 'red' : 'blue';
   setActiveId(next);
+  showPopup(`Iniciando turno do jogador ${next}`, {
+    corner: 'top-left',
+    duration: 1000,
+  });
   clearReachable();
   updateBluePanel(units.blue);
   startTurnTimer();

--- a/tests/ui.test.js
+++ b/tests/ui.test.js
@@ -1,9 +1,17 @@
+import { jest } from '@jest/globals';
 import { passTurn, stopTurnTimer } from '../js/ui.js';
 import { units, setActiveId } from '../js/units.js';
 
 describe('passTurn', () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+  });
+
   afterEach(() => {
     stopTurnTimer();
+    jest.runOnlyPendingTimers();
+    jest.useRealTimers();
+    document.body.innerHTML = '';
   });
 
   test('refills PA for the unit that ended its turn', () => {
@@ -18,6 +26,18 @@ describe('passTurn', () => {
     units.red.pa = 2;
     passTurn();
     expect(units.red.pa).toBe(6);
+  });
+
+  test('displays popup when passing the turn', () => {
+    setActiveId('blue');
+    passTurn();
+    const popup = document.querySelector('.popup');
+    expect(popup).not.toBeNull();
+    expect(popup.textContent).toBe('Iniciando turno do jogador red');
+    stopTurnTimer();
+    jest.advanceTimersByTime(1000);
+    jest.advanceTimersByTime(300);
+    expect(document.querySelector('.popup')).toBeNull();
   });
 });
 


### PR DESCRIPTION
## Summary
- show turn-start popup for active player
- test popup display and removal on turn pass

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a189f3d8a8832eabe732f84dc2f1e6