### PR TITLE
feat: add battle countdown

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -10,7 +10,27 @@ import {
   clearSocoAlcance,
   showFloatingText,
 } from './units.js';
-import { initUI, updateBluePanel, initEnemyTooltip, uiState } from './ui.js';
+import { initUI, updateBluePanel, initEnemyTooltip, uiState, startTurnTimer } from './ui.js';
+
+let overlayEl = null;
+
+export function showOverlay(text = '') {
+  if (!overlayEl) {
+    overlayEl = document.createElement('div');
+    overlayEl.className = 'overlay';
+    document.body.appendChild(overlayEl);
+  }
+  overlayEl.textContent = text;
+  overlayEl.style.display = 'flex';
+}
+
+export async function startBattle() {
+  showOverlay('Desafio contra vermelho');
+  for (let i = 3; i > 0; i--) {
+    await new Promise(r => setTimeout(r, 1000));
+  }
+  startTurnTimer();
+}
 
 async function moveUnitAlongPath(unit, path, cost) {
   for (const step of path.slice(1)) {

--- a/js/map.js
+++ b/js/map.js
@@ -43,6 +43,8 @@ path.forEach((node, idx) => {
   }
 });
 
+import { showOverlay, startBattle } from './main.js';
+
 const playBtn = document.getElementById('play');
 const current = path[stage];
 if (current) {
@@ -58,4 +60,6 @@ playBtn.addEventListener('click', () => {
   localStorage.setItem(playedKey, 'true');
   if (mapScreen) mapScreen.style.display = 'none';
   if (boardScreen) boardScreen.style.display = 'block';
+  showOverlay();
+  startBattle();
 });

--- a/js/ui.js
+++ b/js/ui.js
@@ -138,7 +138,6 @@ export function initUI() {
   updateBluePanel(units.blue);
 
   passBtn.addEventListener('click', passTurn);
-  startTurnTimer();
 }
 
 export function initEnemyTooltip() {

--- a/tests/ui.test.js
+++ b/tests/ui.test.js
@@ -1,5 +1,8 @@
-import { passTurn, stopTurnTimer } from '../js/ui.js';
-import { units, setActiveId } from '../js/units.js';
+import { jest } from '@jest/globals';
+
+const { passTurn, stopTurnTimer, startTurnTimer } = await import('../js/ui.js');
+const { units, setActiveId } = await import('../js/units.js');
+const { startBattle } = await import('../js/main.js');
 
 describe('passTurn', () => {
   afterEach(() => {
@@ -21,3 +24,17 @@ describe('passTurn', () => {
   });
 });
 
+describe('startBattle', () => {
+  afterEach(() => {
+    stopTurnTimer();
+  });
+
+  test('timer starts only after countdown', async () => {
+    const spy = jest.spyOn(global, 'setInterval');
+    startBattle();
+    expect(spy).not.toHaveBeenCalled();
+    await new Promise(r => setTimeout(r, 3100));
+    expect(spy).toHaveBeenCalled();
+    spy.mockRestore();
+  }, 10000);
+});


### PR DESCRIPTION
## Summary
- show overlay and start battle countdown when entering the board
- overlay helper and battle timer bootstrap
- test ensures turn timer starts only after countdown

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a187e2ef78832eab80d1702f198ad7