### PR TITLE
Add victory chest and loot generation

### DIFF
--- a/css/cards.css
+++ b/css/cards.css
@@ -225,3 +225,59 @@
   }
 }
 
+.chest {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  width: 80px;
+  height: 60px;
+  cursor: pointer;
+}
+
+.chest .lid,
+.chest .box {
+  position: absolute;
+  left: 0;
+  width: 100%;
+  background: #b45309;
+  border: 2px solid #78350f;
+}
+
+.chest .lid {
+  height: 20px;
+  top: 0;
+  transition: transform 0.3s;
+  transform-origin: top;
+}
+
+.chest .box {
+  bottom: 0;
+  height: 40px;
+}
+
+.chest:hover .lid {
+  transform: translateY(-100%);
+}
+
+.loot {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  display: flex;
+  gap: 8px;
+}
+
+.loot-item {
+  width: 64px;
+  height: 64px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 32px;
+  border: 2px dashed rgba(255, 255, 255, 0.3);
+  border-radius: 6px;
+  background: rgba(17, 24, 39, 0.9);
+}
+

--- a/js/config.js
+++ b/js/config.js
@@ -1,0 +1,16 @@
+export const itemsConfig = [
+  { id: 'sword', icon: '🗡️' },
+  { id: 'shield', icon: '🛡️' },
+  { id: 'potion', icon: '🧪' },
+  { id: 'bow', icon: '🏹' },
+  { id: 'wand', icon: '✨' }
+];
+
+export function getRandomItems(count = 1) {
+  const result = [];
+  for (let i = 0; i < count; i++) {
+    const item = itemsConfig[Math.floor(Math.random() * itemsConfig.length)];
+    result.push(item);
+  }
+  return result;
+}

--- a/js/main.js
+++ b/js/main.js
@@ -11,6 +11,7 @@ import {
   showFloatingText,
 } from './units.js';
 import { initUI, updateBluePanel, initEnemyTooltip, uiState, startTurnTimer } from './ui.js';
+import { getRandomItems } from './config.js';
 
 let overlayEl = null;
 
@@ -49,6 +50,36 @@ async function animateAttack(attacker, defender, paCost, damage) {
   showFloatingText(attacker, `-${paCost}`, 'pa');
   showFloatingText(defender, `-${damage}`, 'pv');
   await new Promise(r => setTimeout(r, 600));
+}
+
+export function gameOver(result) {
+  if (result !== 'vitoria') return;
+  units.red.el?.remove();
+  setTimeout(() => {
+    const board = document.querySelector('.board');
+    if (!board) return;
+    const chest = document.createElement('div');
+    chest.className = 'chest';
+    chest.innerHTML = '<div class="lid"></div><div class="box"></div>';
+    board.appendChild(chest);
+
+    chest.addEventListener(
+      'click',
+      () => {
+        const loot = document.createElement('div');
+        loot.className = 'loot';
+        const items = getRandomItems(3);
+        items.forEach(it => {
+          const el = document.createElement('div');
+          el.className = 'loot-item';
+          el.textContent = it.icon || it.id;
+          loot.appendChild(el);
+        });
+        board.appendChild(loot);
+      },
+      { once: true }
+    );
+  }, 1000);
 }
 
 document.addEventListener('DOMContentLoaded', () => {

--- a/tests/gameOver.test.js
+++ b/tests/gameOver.test.js
@@ -1,0 +1,28 @@
+import { jest } from '@jest/globals';
+const { gameOver } = await import('../js/main.js');
+const { units } = await import('../js/units.js');
+
+describe('gameOver victory chest', () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+    document.body.innerHTML = '<div class="board"></div>';
+    units.red.el = document.createElement('div');
+    units.red.el.className = 'unit unit-red';
+    document.querySelector('.board').appendChild(units.red.el);
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+    document.body.innerHTML = '';
+  });
+
+  test('shows 3 items after clicking chest', () => {
+    gameOver('vitoria');
+    jest.advanceTimersByTime(1000);
+    const chest = document.querySelector('.chest');
+    expect(chest).not.toBeNull();
+    chest.dispatchEvent(new Event('click'));
+    const items = document.querySelectorAll('.loot-item');
+    expect(items.length).toBe(3);
+  });
+});


### PR DESCRIPTION
## Summary
- spawn chest after victory and remove enemy piece
- open chest to reveal three random items
- style chest and loot display
- test chest click reveals three items

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a18be7ae08832e85a505721bdf2af2