### PR TITLE
feat: add persistent Game Over overlay

### DIFF
--- a/css/overlay.css
+++ b/css/overlay.css
@@ -5,12 +5,23 @@
   right: 0;
   bottom: 0;
   display: flex;
+  flex-direction: column;
   justify-content: center;
   align-items: center;
   background: rgba(0, 0, 0, 0.7);
   color: #fff;
   z-index: 1000;
   animation: fade-in 0.3s;
+  gap: 1rem;
+}
+
+.overlay-btn {
+  padding: 0.5rem 1rem;
+  background: var(--black);
+  color: #fff;
+  border: none;
+  border-radius: 4px;
+  cursor: pointer;
 }
 
 .popup-container {

--- a/js/overlay.js
+++ b/js/overlay.js
@@ -1,15 +1,17 @@
-export function showOverlay(msg, { duration = 2000 } = {}) {
+export function showOverlay(msg, { duration = 2000, persist = false } = {}) {
   const el = document.createElement('div');
   el.className = 'overlay';
   el.textContent = msg;
   document.body.appendChild(el);
 
-  setTimeout(() => {
-    el.classList.add('fade-out');
+  if (!persist) {
     setTimeout(() => {
-      el.remove();
-    }, 300);
-  }, duration);
+      el.classList.add('fade-out');
+      setTimeout(() => {
+        el.remove();
+      }, 300);
+    }, duration);
+  }
 
   return el;
 }

--- a/js/ui.js
+++ b/js/ui.js
@@ -165,4 +165,18 @@ export function initEnemyTooltip() {
   });
 }
 
+export function gameOver(resultado) {
+  if (resultado !== 'derrota') return;
+  const overlay = showOverlay('Game Over', { persist: true });
+  const exitBtn = document.createElement('button');
+  exitBtn.textContent = 'Sair';
+  exitBtn.className = 'overlay-btn';
+  overlay.appendChild(exitBtn);
+  exitBtn.addEventListener('click', () => {
+    localStorage.removeItem('stage');
+    localStorage.removeItem('played');
+    window.location.reload();
+  });
+}
+
 export { showOverlay, showPopup };


### PR DESCRIPTION
## Summary
- show Game Over overlay with persistent exit button
- clear progress on exit and reload to map
- support persistent overlays and style central button

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a18be7c078832e922f8a29fee4fc59