### PR TITLE
Add item definitions with apply effects and tests

### DIFF
--- a/js/items.js
+++ b/js/items.js
@@ -1,0 +1,68 @@
+export const ITEMS = [
+  {
+    id: 'vida+2',
+    emoji: '💖',
+    paCost: 0,
+    damage: 0,
+    range: 0,
+    effect: 'Cura 2 PV',
+    apply(unit) {
+      unit.pv += 2;
+    }
+  },
+  {
+    id: 'espada',
+    emoji: '🗡️',
+    paCost: 2,
+    damage: 3,
+    range: 1,
+    effect: 'Aumenta ataque em 3',
+    apply(unit) {
+      unit.attack = (unit.attack || 0) + 3;
+    }
+  },
+  {
+    id: 'martelo',
+    emoji: '🔨',
+    paCost: 3,
+    damage: 4,
+    range: 1,
+    effect: 'Aumenta ataque em 4',
+    apply(unit) {
+      unit.attack = (unit.attack || 0) + 4;
+    }
+  },
+  {
+    id: 'bomba',
+    emoji: '💣',
+    paCost: 4,
+    damage: 5,
+    range: 2,
+    effect: 'Causa 5 de dano',
+    apply(unit) {
+      unit.pv -= 5;
+    }
+  },
+  {
+    id: 'escudo',
+    emoji: '🛡️',
+    paCost: 0,
+    damage: 0,
+    range: 0,
+    effect: 'Aumenta PV em 3',
+    apply(unit) {
+      unit.pv += 3;
+    }
+  },
+  {
+    id: 'cafe',
+    emoji: '☕',
+    paCost: 0,
+    damage: 0,
+    range: 0,
+    effect: 'Restaura 2 PA',
+    apply(unit) {
+      unit.pa += 2;
+    }
+  }
+];

--- a/tests/items.test.js
+++ b/tests/items.test.js
@@ -1,0 +1,39 @@
+import { ITEMS } from '../js/items.js';
+
+describe('ITEMS configuration', () => {
+  test('items array contains six objects with required properties', () => {
+    expect(Array.isArray(ITEMS)).toBe(true);
+    expect(ITEMS).toHaveLength(6);
+
+    for (const it of ITEMS) {
+      expect(typeof it.id).toBe('string');
+      expect(typeof it.emoji).toBe('string');
+      expect(typeof it.paCost).toBe('number');
+      expect(typeof it.damage).toBe('number');
+      expect(typeof it.range).toBe('number');
+      expect(typeof it.effect).toBe('string');
+      expect(typeof it.apply).toBe('function');
+    }
+  });
+
+  test('apply functions modify unit stats accordingly', () => {
+    const base = { pv: 10, pa: 5, attack: 1 };
+    const find = id => ITEMS.find(i => i.id === id);
+
+    const u1 = { ...base };
+    find('vida+2').apply(u1);
+    expect(u1.pv).toBe(12);
+
+    const u2 = { ...base };
+    find('espada').apply(u2);
+    expect(u2.attack).toBe(base.attack + 3);
+
+    const u3 = { ...base };
+    find('cafe').apply(u3);
+    expect(u3.pa).toBe(base.pa + 2);
+
+    const u4 = { ...base };
+    find('bomba').apply(u4);
+    expect(u4.pv).toBe(base.pv - 5);
+  });
+});


### PR DESCRIPTION
## Summary
- create `ITEMS` module providing six usable items with stats and apply effects
- test item properties and their impact on unit attributes

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a18d2b9ad4832ea6a3c0a0627970c1