### PR TITLE
Implement game over logic and tests

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -10,9 +10,16 @@ import {
   clearSocoAlcance,
   showFloatingText,
 } from './units.js';
-import { initUI, updateBluePanel, initEnemyTooltip, uiState, startTurnTimer } from './ui.js';
+import * as ui from './ui.js';
+
+const { initUI, updateBluePanel, initEnemyTooltip, startTurnTimer } = ui;
 
 let overlayEl = null;
+
+export function checkGameOver() {
+  if (units.blue.pv <= 0) ui.gameOver('derrota');
+  else if (units.red.pv <= 0) ui.gameOver('vitoria');
+}
 
 export function showOverlay(text = '') {
   if (!overlayEl) {
@@ -92,7 +99,7 @@ document.addEventListener('DOMContentLoaded', () => {
     if (!cell) return;
 
     const active = getActive();
-    if (uiState.socoSelecionado && cell.classList.contains('attackable')) {
+    if (ui.uiState.socoSelecionado && cell.classList.contains('attackable')) {
       const r = Number(cell.dataset.row);
       const c = Number(cell.dataset.col);
       const enemy = getInactive();
@@ -104,9 +111,10 @@ document.addEventListener('DOMContentLoaded', () => {
         await animateAttack(active, enemy, paCost, damage);
         updateBluePanel(units.blue);
         mountUnit(enemy);
+        checkGameOver();
       }
-      uiState.socoSelecionado = false;
-      uiState.socoSlot.classList.remove('is-selected');
+      ui.uiState.socoSelecionado = false;
+      ui.uiState.socoSlot.classList.remove('is-selected');
       clearSocoAlcance();
       return;
     }

--- a/js/ui.js
+++ b/js/ui.js
@@ -7,6 +7,7 @@ import {
   clearSocoAlcance as clearSocoAlcanceUnits,
 } from './units.js';
 import { showOverlay, showPopup } from './overlay.js';
+import { checkGameOver } from './main.js';
 
 export const uiState = {
   socoSlot: null,
@@ -63,6 +64,12 @@ export function stopTurnTimer() {
   }
 }
 
+export function gameOver(result) {
+  stopTurnTimer();
+  const msg = result === 'vitoria' ? 'Vitória!' : 'Derrota!';
+  showOverlay(msg);
+}
+
 export function passTurn() {
   const finished = getActive();
   finished.pm = 3;
@@ -75,7 +82,10 @@ export function passTurn() {
   });
   clearReachable();
   updateBluePanel(units.blue);
-  startTurnTimer();
+  checkGameOver();
+  if (units.blue.pv > 0 && units.red.pv > 0) {
+    startTurnTimer();
+  }
 }
 
 export function initUI() {

--- a/tests/main.test.js
+++ b/tests/main.test.js
@@ -1,0 +1,55 @@
+import { jest } from '@jest/globals';
+
+const ui = await import('../js/ui.js');
+const { passTurn, stopTurnTimer } = ui;
+const { units, setActiveId } = await import('../js/units.js');
+const { checkGameOver } = await import('../js/main.js');
+
+describe('game over logic', () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+    units.blue.pv = 10;
+    units.red.pv = 10;
+    setActiveId('blue');
+  });
+
+  afterEach(() => {
+    stopTurnTimer();
+    jest.runOnlyPendingTimers();
+    jest.useRealTimers();
+    document.body.innerHTML = '';
+  });
+
+  test('checkGameOver triggers victory overlay when red PV <= 0', () => {
+    units.red.pv = 0;
+    checkGameOver();
+    const overlay = document.querySelector('.overlay');
+    expect(overlay).not.toBeNull();
+    expect(overlay.textContent).toBe('Vitória!');
+  });
+
+  test('checkGameOver triggers defeat overlay when blue PV <= 0', () => {
+    units.blue.pv = 0;
+    checkGameOver();
+    const overlay = document.querySelector('.overlay');
+    expect(overlay).not.toBeNull();
+    expect(overlay.textContent).toBe('Derrota!');
+  });
+
+  test('passTurn checks for game over (victory)', () => {
+    units.red.pv = 0;
+    passTurn();
+    const overlay = document.querySelector('.overlay');
+    expect(overlay).not.toBeNull();
+    expect(overlay.textContent).toBe('Vitória!');
+  });
+
+  test('passTurn checks for game over (defeat)', () => {
+    units.blue.pv = 0;
+    passTurn();
+    const overlay = document.querySelector('.overlay');
+    expect(overlay).not.toBeNull();
+    expect(overlay.textContent).toBe('Derrota!');
+  });
+});
+


### PR DESCRIPTION
## Summary
- Add `checkGameOver` to evaluate unit PV and trigger end-of-game after attacks
- Provide `gameOver` UI handler that stops timers and shows victory/defeat overlays
- Cover victory and defeat scenarios with new Jest tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a18c74849c832ea56d5c0e7af94a9c