### PR TITLE
Apply loot effects and advance stage after chest selection

### DIFF
--- a/css/turn-panel.css
+++ b/css/turn-panel.css
@@ -26,7 +26,8 @@
   height: 64px;
 }
 
-.slot .card-soco {
+.slot .card-soco,
+.slot .card-extra {
   display: flex;
   align-items: center;
   justify-content: center;
@@ -34,7 +35,8 @@
   position: relative;
 }
 
-.slot .card-soco .atk {
+.slot .card-soco .atk,
+.slot .card-extra .atk {
   position: absolute;
   top: 2px;
   right: 4px;

--- a/js/config.js
+++ b/js/config.js
@@ -1,9 +1,51 @@
+//
+// Items available as loot in the game.  Besides the visual `icon`, each item
+// exposes an `apply` function that mutates the provided unit.  Some items can
+// also grant an additional attack card for the turn panel and are flagged with
+// `extraAttack`.
+//
 export const itemsConfig = [
-  { id: 'sword', icon: '🗡️' },
-  { id: 'shield', icon: '🛡️' },
-  { id: 'potion', icon: '🧪' },
-  { id: 'bow', icon: '🏹' },
-  { id: 'wand', icon: '✨' }
+  {
+    id: 'sword',
+    icon: '🗡️',
+    // Adds extra attack damage and grants an extra attack card
+    apply: unit => {
+      unit.pa += 2;
+    },
+    extraAttack: true,
+  },
+  {
+    id: 'shield',
+    icon: '🛡️',
+    // Small health boost
+    apply: unit => {
+      unit.pv += 2;
+    },
+  },
+  {
+    id: 'potion',
+    icon: '🧪',
+    // Restores one health point
+    apply: unit => {
+      unit.pv += 1;
+    },
+  },
+  {
+    id: 'bow',
+    icon: '🏹',
+    // Grants one additional action point
+    apply: unit => {
+      unit.pa += 1;
+    },
+  },
+  {
+    id: 'wand',
+    icon: '✨',
+    // Increases movement by one point
+    apply: unit => {
+      unit.pm += 1;
+    },
+  },
 ];
 
 export function getRandomItems(count = 1) {

--- a/js/main.js
+++ b/js/main.js
@@ -73,6 +73,42 @@ export function gameOver(result) {
           const el = document.createElement('div');
           el.className = 'loot-item';
           el.textContent = it.icon || it.id;
+
+          // When the player chooses an item we apply its effects, update the
+          // UI and then transition back to the map screen advancing the stage.
+          el.addEventListener(
+            'click',
+            () => {
+              it.apply?.(units.blue);
+              updateBluePanel(units.blue);
+
+              // If the item grants an additional attack, append a card to the
+              // turn panel so the player can use it on the next battle.
+              if (it.extraAttack) {
+                const slots = document.querySelector('.turn-panel .slots');
+                const empty = Array.from(slots?.children || []).find(
+                  s => s.children.length === 0,
+                );
+                if (empty) {
+                  const card = document.createElement('div');
+                  card.className = 'card-extra';
+                  card.textContent = it.icon || it.id;
+                  empty.appendChild(card);
+                }
+              }
+
+              // Advance stage and show the map screen again
+              const stageKey = 'stage';
+              const stage = Number(localStorage.getItem(stageKey)) || 0;
+              localStorage.setItem(stageKey, String(stage + 1));
+              const boardScreen = document.getElementById('board-screen');
+              const mapScreen = document.getElementById('map-screen');
+              if (boardScreen) boardScreen.style.display = 'none';
+              if (mapScreen) mapScreen.style.display = 'block';
+            },
+            { once: true },
+          );
+
           loot.appendChild(el);
         });
         board.appendChild(loot);

--- a/tests/gameOver.test.js
+++ b/tests/gameOver.test.js
@@ -1,14 +1,20 @@
 import { jest } from '@jest/globals';
 const { gameOver } = await import('../js/main.js');
 const { units } = await import('../js/units.js');
+const ui = await import('../js/ui.js');
 
 describe('gameOver victory chest', () => {
   beforeEach(() => {
     jest.useFakeTimers();
-    document.body.innerHTML = '<div class="board"></div>';
+    localStorage.clear();
+    document.body.innerHTML = `
+      <div id="map-screen" style="display:none"></div>
+      <div class="page" id="board-screen"><div class="board"></div></div>
+    `;
     units.red.el = document.createElement('div');
     units.red.el.className = 'unit unit-red';
     document.querySelector('.board').appendChild(units.red.el);
+    ui.initUI();
   });
 
   afterEach(() => {
@@ -24,5 +30,19 @@ describe('gameOver victory chest', () => {
     chest.dispatchEvent(new Event('click'));
     const items = document.querySelectorAll('.loot-item');
     expect(items.length).toBe(3);
+  });
+
+  test('selecting an item applies effect and advances stage', () => {
+    // Ensure deterministic loot: always pick the first item (sword)
+    jest.spyOn(Math, 'random').mockReturnValue(0);
+    units.blue.pa = 6;
+    gameOver('vitoria');
+    jest.advanceTimersByTime(1000);
+    document.querySelector('.chest')?.dispatchEvent(new Event('click'));
+    const lootItem = document.querySelector('.loot-item');
+    lootItem?.dispatchEvent(new Event('click'));
+    expect(localStorage.getItem('stage')).toBe('1');
+    const paEl = document.querySelector('.pa');
+    expect(paEl?.textContent).toBe('8');
   });
 });


### PR DESCRIPTION
## Summary
- add item effects with optional extra attack flag
- apply loot selections to blue unit, update UI, and advance map stage
- test stage increment and panel update after choosing loot

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a18d2d1590832ea8fd87913e83fd95