### PR TITLE
Fix overlay stuck after starting battle

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -12,21 +12,10 @@ import {
 } from './units.js';
 import { initUI, updateBluePanel, initEnemyTooltip, uiState, startTurnTimer } from './ui.js';
 import { getRandomItems } from './config.js';
-
-let overlayEl = null;
-
-export function showOverlay(text = '') {
-  if (!overlayEl) {
-    overlayEl = document.createElement('div');
-    overlayEl.className = 'overlay';
-    document.body.appendChild(overlayEl);
-  }
-  overlayEl.textContent = text;
-  overlayEl.style.display = 'flex';
-}
+import { showOverlay } from './overlay.js';
 
 export async function startBattle() {
-  showOverlay('Desafio contra vermelho');
+  showOverlay('Desafio contra vermelho', { duration: 3000 });
   for (let i = 3; i > 0; i--) {
     await new Promise(r => setTimeout(r, 1000));
   }
@@ -163,3 +152,5 @@ document.addEventListener('DOMContentLoaded', () => {
 
   console.log('[Tabuleiro] Unidades inicializadas', units);
 });
+
+export { showOverlay };

--- a/js/overlay.js
+++ b/js/overlay.js
@@ -1,4 +1,4 @@
-export function showOverlay(msg, { duration = 2000, persist = false } = {}) {
+export function showOverlay(msg = '', { duration = 2000, persist = false } = {}) {
   const el = document.createElement('div');
   el.className = 'overlay';
   el.textContent = msg;


### PR DESCRIPTION
## Summary
- Fix overlay not closing by using reusable overlay helper
- Allow showOverlay without message

## Testing
- `CI=true npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a18d6bbfac832e97b2f1ff1db92c1e