### PR TITLE
fix: remove duplicate showOverlay declaration

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -17,22 +17,9 @@ const { initUI, updateBluePanel, initEnemyTooltip, startTurnTimer } = ui;
 import { getRandomItems } from './config.js';
 import { showOverlay } from './overlay.js';
 
-
-let overlayEl = null;
-
 export function checkGameOver() {
   if (units.blue.pv <= 0) ui.gameOver('derrota');
   else if (units.red.pv <= 0) ui.gameOver('vitoria');
-}
-
-export function showOverlay(text = '') {
-  if (!overlayEl) {
-    overlayEl = document.createElement('div');
-    overlayEl.className = 'overlay';
-    document.body.appendChild(overlayEl);
-  }
-  overlayEl.textContent = text;
-  overlayEl.style.display = 'flex';
 }
 
 export async function startBattle() {

--- a/js/ui.js
+++ b/js/ui.js
@@ -175,18 +175,4 @@ export function initEnemyTooltip() {
   });
 }
 
-export function gameOver(resultado) {
-  if (resultado !== 'derrota') return;
-  const overlay = showOverlay('Game Over', { persist: true });
-  const exitBtn = document.createElement('button');
-  exitBtn.textContent = 'Sair';
-  exitBtn.className = 'overlay-btn';
-  overlay.appendChild(exitBtn);
-  exitBtn.addEventListener('click', () => {
-    localStorage.removeItem('stage');
-    localStorage.removeItem('played');
-    window.location.reload();
-  });
-}
-
 export { showOverlay, showPopup };


### PR DESCRIPTION
## Summary
- use overlay.js showOverlay instead of redefining it in main.js
- drop duplicate gameOver export from ui module

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a18f70fc94832ea9150b598365c330