### PR TITLE
Fix map stage progression after victory

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -98,6 +98,8 @@ export function gameOver(result) {
               const stageKey = 'stage';
               const stage = Number(localStorage.getItem(stageKey)) || 0;
               localStorage.setItem(stageKey, String(stage + 1));
+              const playedKey = 'played';
+              localStorage.setItem(playedKey, 'true');
               const boardScreen = document.getElementById('board-screen');
               const mapScreen = document.getElementById('map-screen');
               if (boardScreen) boardScreen.style.display = 'none';

--- a/js/map.js
+++ b/js/map.js
@@ -15,7 +15,7 @@ if (Number.isNaN(stage)) {
 }
 
 if (localStorage.getItem(playedKey)) {
-  stage += 1;
+  stage = Number(localStorage.getItem(stageKey)) || stage;
   localStorage.removeItem(playedKey);
 }
 
@@ -57,7 +57,6 @@ if (current) {
 
 playBtn.addEventListener('click', () => {
   localStorage.setItem(stageKey, stage);
-  localStorage.setItem(playedKey, 'true');
   if (mapScreen) mapScreen.style.display = 'none';
   if (boardScreen) boardScreen.style.display = 'block';
   showOverlay();

--- a/tests/map.test.js
+++ b/tests/map.test.js
@@ -1,0 +1,28 @@
+describe('map progression', () => {
+  beforeEach(() => {
+    localStorage.clear();
+    document.body.innerHTML = `
+      <div id="map-screen">
+        <div class="map-container" id="map"></div>
+        <button id="play"></button>
+      </div>
+      <div id="board-screen"></div>
+    `;
+  });
+
+  afterEach(() => {
+    document.body.innerHTML = '';
+  });
+
+  test('advances to next node after victory', async () => {
+    localStorage.setItem('stage', '1');
+    localStorage.setItem('played', 'true');
+    await import('../js/map.js');
+    const nodes = document.querySelectorAll('.map-node');
+    const currentIndex = Array.from(nodes).findIndex(n =>
+      n.classList.contains('current'),
+    );
+    expect(currentIndex).toBe(1);
+    expect(localStorage.getItem('played')).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary
- Read updated `stage` from storage when returning to map
- Mark stage as played only after closing the loot chest
- Test map node advancement after victory

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a191205c60832eb6c8bf83fcffca81