### PR TITLE
Add corner positioning to popups

### DIFF
--- a/css/overlay.css
+++ b/css/overlay.css
@@ -26,12 +26,34 @@
 
 .popup-container {
   position: fixed;
-  top: 1rem;
-  right: 1rem;
   display: flex;
   flex-direction: column;
   gap: 0.5rem;
   z-index: 1000;
+}
+
+.popup-container.top-right {
+  top: 1rem;
+  right: 1rem;
+  align-items: flex-end;
+}
+
+.popup-container.top-left {
+  top: 1rem;
+  left: 1rem;
+  align-items: flex-start;
+}
+
+.popup-container.bottom-right {
+  bottom: 1rem;
+  right: 1rem;
+  align-items: flex-end;
+}
+
+.popup-container.bottom-left {
+  bottom: 1rem;
+  left: 1rem;
+  align-items: flex-start;
 }
 
 .popup {

--- a/js/overlay.js
+++ b/js/overlay.js
@@ -16,11 +16,11 @@ export function showOverlay(msg = '', { duration = 2000, persist = false } = {})
   return el;
 }
 
-export function showPopup(msg, { duration = 2000 } = {}) {
-  let container = document.querySelector('.popup-container');
+export function showPopup(msg, { duration = 2000, corner = 'top-right' } = {}) {
+  let container = document.querySelector(`.popup-container.${corner}`);
   if (!container) {
     container = document.createElement('div');
-    container.className = 'popup-container';
+    container.className = `popup-container ${corner}`;
     document.body.appendChild(container);
   }
 

--- a/tests/overlay.test.js
+++ b/tests/overlay.test.js
@@ -22,9 +22,11 @@ describe('overlay helpers', () => {
   });
 
   test('showPopup adds and removes element', () => {
-    showPopup('Oi', { duration: 100 });
+    showPopup('Oi', { duration: 100, corner: 'top-right' });
     expect(document.querySelector('.popup')).not.toBeNull();
-    expect(document.querySelector('.popup-container')).not.toBeNull();
+    expect(
+      document.querySelector('.popup-container.top-right'),
+    ).not.toBeNull();
 
     jest.advanceTimersByTime(100);
     jest.advanceTimersByTime(300);


### PR DESCRIPTION
## Summary
- allow specifying popup corner when showing notifications
- support new corner CSS classes for popup container positioning
- update tests for new popup API

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a19373fc24832ebad9bccd649854bc