### PR TITLE
Show popup for blue turn start

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -30,8 +30,10 @@ export async function startBattle() {
   }
   overlay.classList.add('fade-out');
   setTimeout(() => overlay.remove(), 300);
-  showPopup('Turno do jogador azul');
   startTurnTimer();
+  showPopup('Iniciando turno do jogador azul', {
+    corner: 'top-left',
+  });
 }
 
 async function moveUnitAlongPath(unit, path, cost) {

--- a/tests/ui.test.js
+++ b/tests/ui.test.js
@@ -45,6 +45,7 @@ describe('passTurn', () => {
 describe('startBattle', () => {
   afterEach(() => {
     stopTurnTimer();
+    document.body.innerHTML = '';
   });
 
   test('timer starts only after countdown', async () => {
@@ -54,5 +55,14 @@ describe('startBattle', () => {
     await new Promise(r => setTimeout(r, 3100));
     expect(spy).toHaveBeenCalled();
     spy.mockRestore();
+  }, 10000);
+
+  test('displays popup for blue turn at top-left', async () => {
+    startBattle();
+    await new Promise(r => setTimeout(r, 3100));
+    const popup = document.querySelector('.popup');
+    expect(popup).not.toBeNull();
+    expect(popup.textContent).toBe('Iniciando turno do jogador azul');
+    expect(document.querySelector('.popup-container.top-left')).not.toBeNull();
   }, 10000);
 });


### PR DESCRIPTION
## Summary
- display popup announcing blue player's turn after battle countdown
- test that battle start renders top-left popup for blue turn

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a20f610c94832eb4907a4108113e1c