### PR TITLE
Add exit option on defeat overlay

### DIFF
--- a/js/ui.js
+++ b/js/ui.js
@@ -66,8 +66,29 @@ export function stopTurnTimer() {
 
 export function gameOver(result) {
   stopTurnTimer();
-  const msg = result === 'vitoria' ? 'Vitória!' : 'Derrota!';
-  showOverlay(msg);
+  if (result === 'derrota') {
+    const overlay = showOverlay('Derrota!', { persist: true });
+    const exitBtn = document.createElement('button');
+    exitBtn.type = 'button';
+    exitBtn.className = 'overlay-btn';
+    exitBtn.textContent = 'Sair';
+    overlay.appendChild(exitBtn);
+    exitBtn.addEventListener(
+      'click',
+      () => {
+        localStorage.clear();
+        const board = document.getElementById('board-screen');
+        const map = document.getElementById('map-screen');
+        if (board) board.style.display = 'none';
+        if (map) map.style.display = 'block';
+        window.location.reload();
+      },
+      { once: true },
+    );
+  } else {
+    const msg = result === 'vitoria' ? 'Vitória!' : 'Derrota!';
+    showOverlay(msg);
+  }
 }
 
 export function passTurn() {

--- a/tests/main.test.js
+++ b/tests/main.test.js
@@ -33,7 +33,9 @@ describe('game over logic', () => {
     checkGameOver();
     const overlay = document.querySelector('.overlay');
     expect(overlay).not.toBeNull();
-    expect(overlay.textContent).toBe('Derrota!');
+    expect(overlay?.firstChild?.textContent).toBe('Derrota!');
+    const btn = overlay?.querySelector('button');
+    expect(btn?.textContent).toBe('Sair');
   });
 
   test('passTurn checks for game over (victory)', () => {
@@ -49,7 +51,9 @@ describe('game over logic', () => {
     passTurn();
     const overlay = document.querySelector('.overlay');
     expect(overlay).not.toBeNull();
-    expect(overlay.textContent).toBe('Derrota!');
+    expect(overlay?.firstChild?.textContent).toBe('Derrota!');
+    const btn = overlay?.querySelector('button');
+    expect(btn?.textContent).toBe('Sair');
   });
 });
 


### PR DESCRIPTION
## Summary
- add persistent defeat overlay with a Sair button
- reset progress and return to map when exiting defeat overlay
- update tests for new defeat overlay behavior

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a21b4ad4a8832e8f3204540a6d6e35