### PR TITLE
Fix victory overlay blocking chest interaction

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -68,6 +68,11 @@ export function gameOver(result) {
     chest.innerHTML = '<div class="lid"></div><div class="box"></div>';
     board.appendChild(chest);
 
+    // Allow the player to click the chest while keeping the victory message on
+    // screen. Without disabling pointer events, the overlay element would sit
+    // above the board and swallow all click interactions, blocking the chest.
+    overlay.style.pointerEvents = 'none';
+
     chest.addEventListener(
       'click',
       () => {

--- a/tests/gameOver.test.js
+++ b/tests/gameOver.test.js
@@ -22,6 +22,16 @@ describe('gameOver victory chest', () => {
     document.body.innerHTML = '';
   });
 
+  test('overlay does not block chest interaction', () => {
+    gameOver('vitoria');
+    jest.advanceTimersByTime(1000);
+    const overlay = document.querySelector('.overlay');
+    expect(overlay).not.toBeNull();
+    // After the chest appears the overlay should allow pointer events to pass
+    // through so the player can click the chest.
+    expect(overlay?.style.pointerEvents).toBe('none');
+  });
+
   test('shows 3 items after clicking chest', () => {
     gameOver('vitoria');
     jest.advanceTimersByTime(1000);


### PR DESCRIPTION
## Summary
- allow clicking the chest by disabling pointer events on the victory overlay
- test that overlay no longer blocks the chest

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a22053f360832e8afa2a30cef38675