### PR TITLE
Animate units with transform transitions

### DIFF
--- a/css/cards.css
+++ b/css/cards.css
@@ -17,8 +17,6 @@
 /* Unidade sobre a célula */
 .unit {
   position: absolute;
-  top: 50%;
-  left: 50%;
   transform: translate(-50%, -50%);
   width: 60%;
   aspect-ratio: 1 / 1;
@@ -27,6 +25,7 @@
   border-radius: 8px;
   box-shadow: 0 6px 12px rgba(0,0,0,.25);
   cursor: pointer;
+  transition: transform 0.3s linear;
 }
 
 .unit.shake {

--- a/js/main.js
+++ b/js/main.js
@@ -9,6 +9,7 @@ import {
   mountUnit,
   clearSocoAlcance,
   showFloatingText,
+  getCoords,
 } from './units.js';
 
 import * as ui from './ui.js';
@@ -37,11 +38,31 @@ export async function startBattle() {
 }
 
 async function moveUnitAlongPath(unit, path, cost) {
-  for (const step of path.slice(1)) {
-    unit.pos = step;
-    mountUnit(unit);
-    await new Promise(r => setTimeout(r, 300));
+  if (path.length < 2) {
+    showFloatingText(unit, `-${cost}`, 'pm');
+    return;
   }
+  const dest = path[path.length - 1];
+  const { x: endX, y: endY } = getCoords(dest.row, dest.col);
+  const dx = endX - unit.x;
+  const dy = endY - unit.y;
+
+  await new Promise(resolve => {
+    if (dx === 0 && dy === 0) {
+      resolve();
+      return;
+    }
+    const handler = () => resolve();
+    unit.el.addEventListener('transitionend', handler, { once: true });
+    unit.el.style.transform = `translate(-50%, -50%) translate(${dx}px, ${dy}px)`;
+  });
+
+  unit.pos = dest;
+  unit.x = endX;
+  unit.y = endY;
+  unit.el.style.left = `${endX}px`;
+  unit.el.style.top = `${endY}px`;
+  unit.el.style.transform = 'translate(-50%, -50%)';
   showFloatingText(unit, `-${cost}`, 'pm');
 }
 

--- a/js/units.js
+++ b/js/units.js
@@ -2,6 +2,7 @@ import { ROWS, COLS, rowColToIndex, isInside } from './board-utils.js';
 import { computeReachable } from './pathfinding.js';
 
 let cards = [];
+let board = null;
 
 export const units = {
   blue: {
@@ -10,6 +11,8 @@ export const units = {
     pm: 3,
     pa: 6,
     pos: { row: 5, col: 3 },
+    x: 0,
+    y: 0,
     allow: null,
     el: null,
   },
@@ -19,6 +22,8 @@ export const units = {
     pm: 3,
     pa: 6,
     pos: { row: 0, col: 0 },
+    x: 0,
+    y: 0,
     allow: null,
     el: null,
   },
@@ -34,6 +39,7 @@ export function setActiveId(id) {
 
 export function initUnits(cardEls, isBlue, isRed) {
   cards = cardEls;
+  board = document.querySelector('.board') || document.body;
   units.blue.allow = isBlue;
   units.red.allow = isRed;
   units.blue.el = createUnitEl('blue');
@@ -50,11 +56,29 @@ export function createUnitEl(id) {
   return el;
 }
 
-export function mountUnit(unit) {
-  const idx = rowColToIndex(unit.pos.row, unit.pos.col);
+export function getCoords(row, col) {
+  const idx = rowColToIndex(row, col);
   const host = cards[idx];
-  if (!host) return;
-  host.appendChild(unit.el);
+  if (!host || !board) return { x: 0, y: 0, size: 0 };
+  const boardRect = board.getBoundingClientRect();
+  const rect = host.getBoundingClientRect();
+  const x = rect.left - boardRect.left + rect.width / 2;
+  const y = rect.top - boardRect.top + rect.height / 2;
+  const size = rect.width * 0.6;
+  return { x, y, size };
+}
+
+export function mountUnit(unit) {
+  if (!board) return;
+  const { x, y, size } = getCoords(unit.pos.row, unit.pos.col);
+  unit.x = x;
+  unit.y = y;
+  unit.el.style.width = `${size}px`;
+  unit.el.style.height = `${size}px`;
+  unit.el.style.left = `${x}px`;
+  unit.el.style.top = `${y}px`;
+  unit.el.style.transform = 'translate(-50%, -50%)';
+  if (unit.el.parentElement !== board) board.appendChild(unit.el);
 }
 
 export function reflectActiveStyles() {


### PR DESCRIPTION
## Summary
- Position unit elements absolutely on the board and store pixel coordinates
- Animate movement via CSS transform translation, awaiting transition end
- Add transform transition styling for smoother unit motion

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a224608014832eaa3a308d46c03ea3