### PR TITLE
Fix missing units after entering board

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -24,6 +24,14 @@ export function checkGameOver() {
 }
 
 export async function startBattle() {
+  // Recalcula a posição das unidades após o tabuleiro ficar visível. Caso os
+  // elementos sejam montados enquanto o tabuleiro está oculto (`display: none`),
+  // `getBoundingClientRect` retorna dimensões zero e as unidades desaparecem.
+  // Montá-las novamente garante que largura, altura e posição sejam atualizadas
+  // corretamente quando a batalha inicia.
+  mountUnit(units.blue);
+  mountUnit(units.red);
+
   const overlay = showOverlay('Desafio contra vermelho', { persist: true });
   for (let i = 3; i > 0; i--) {
     overlay.textContent = String(i);


### PR DESCRIPTION
## Summary
- Recalculate unit positioning when starting a battle so units remain visible once the board screen is shown.

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a2299ef568832eaa6ae41af29cb99a