### PR TITLE
Fix unit snapping triggering extra transition

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -45,7 +45,7 @@ export async function startBattle() {
   });
 }
 
-async function moveUnitAlongPath(unit, path, cost) {
+export async function moveUnitAlongPath(unit, path, cost) {
   if (path.length < 2) {
     showFloatingText(unit, `-${cost}`, 'pm');
     return;
@@ -68,9 +68,18 @@ async function moveUnitAlongPath(unit, path, cost) {
   unit.pos = dest;
   unit.x = endX;
   unit.y = endY;
-  unit.el.style.left = `${endX}px`;
-  unit.el.style.top = `${endY}px`;
-  unit.el.style.transform = 'translate(-50%, -50%)';
+
+  // Temporarily disable transform transitions to avoid a second animation
+  const el = unit.el;
+  const prevTransition = el.style.transition;
+  el.style.transition = 'none';
+  el.style.left = `${endX}px`;
+  el.style.top = `${endY}px`;
+  el.style.transform = 'translate(-50%, -50%)';
+  // Force reflow so the transition reset takes effect
+  void el.offsetWidth;
+  el.style.transition = prevTransition;
+
   showFloatingText(unit, `-${cost}`, 'pm');
 }
 

--- a/tests/moveUnitAlongPath.test.js
+++ b/tests/moveUnitAlongPath.test.js
@@ -1,0 +1,56 @@
+import { jest } from '@jest/globals';
+
+const getCoords = jest.fn((row, col) => ({ x: col * 10, y: row * 10 }));
+const showFloatingText = jest.fn();
+
+jest.unstable_mockModule('../js/units.js', () => ({
+  units: {},
+  initUnits: jest.fn(),
+  getActive: jest.fn(),
+  getInactive: jest.fn(),
+  showReachableFor: jest.fn(),
+  mountUnit: jest.fn(),
+  clearSocoAlcance: jest.fn(),
+  showFloatingText,
+  getCoords,
+}));
+
+jest.unstable_mockModule('../js/ui.js', () => ({
+  initUI: jest.fn(),
+  updateBluePanel: jest.fn(),
+  initEnemyTooltip: jest.fn(),
+  startTurnTimer: jest.fn(),
+}));
+
+jest.unstable_mockModule('../js/overlay.js', () => ({
+  showOverlay: jest.fn(),
+  showPopup: jest.fn(),
+}));
+
+jest.unstable_mockModule('../js/config.js', () => ({
+  getRandomItems: jest.fn(),
+}));
+
+const { moveUnitAlongPath } = await import('../js/main.js');
+
+test('moveUnitAlongPath snaps unit to destination without extra transition', async () => {
+  const el = document.createElement('div');
+  el.style.transition = 'transform 0.3s linear';
+  let transitionCount = 0;
+  el.addEventListener('transitionend', () => transitionCount++);
+
+  const unit = { el, x: 0, y: 0, pos: { row: 0, col: 0 } };
+  const path = [
+    { row: 0, col: 0 },
+    { row: 1, col: 2 },
+  ];
+
+  const promise = moveUnitAlongPath(unit, path, 1);
+  // simulate end of movement transition
+  el.dispatchEvent(new Event('transitionend'));
+  await promise;
+
+  expect(el.style.transform).toBe('translate(-50%, -50%)');
+  expect(transitionCount).toBe(1);
+});
+


### PR DESCRIPTION
## Summary
- prevent double animation by temporarily disabling transform transitions before snapping unit to final position
- add regression test to ensure unit snapping leaves no extra transitions

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a22f7a4444832ea03f319e5d188422