### PR TITLE
Enable board-based unit attacks

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -164,7 +164,8 @@ export function gameOver(result) {
 
 document.addEventListener('DOMContentLoaded', () => {
   const grid = document.querySelector('.grid');
-  if (!grid) return;
+  const boardEl = document.querySelector('.board');
+  if (!grid || !boardEl) return;
 
   const cards = Array.from(grid.children);
   cards.forEach((el, i) => {
@@ -196,16 +197,27 @@ document.addEventListener('DOMContentLoaded', () => {
     });
   });
 
-  grid.addEventListener('click', async (ev) => {
+  boardEl.addEventListener('click', async ev => {
     const target = ev.target;
     if (!(target instanceof HTMLElement)) return;
-    const cell = target.closest('.card');
-    if (!cell) return;
+    let cell = target.closest('.card');
+    let r, c;
+    if (cell) {
+      r = Number(cell.dataset.row);
+      c = Number(cell.dataset.col);
+    } else {
+      const unitEl = target.closest('.unit');
+      if (unitEl) {
+        r = Number(unitEl.dataset.row);
+        c = Number(unitEl.dataset.col);
+        const idx = rowColToIndex(r, c);
+        cell = cards[idx];
+      }
+    }
+    if (!cell || r === undefined || c === undefined) return;
 
     const active = getActive();
     if (ui.uiState.socoSelecionado && cell.classList.contains('attackable')) {
-      const r = Number(cell.dataset.row);
-      const c = Number(cell.dataset.col);
       const enemy = getInactive();
       if (enemy.pos.row === r && enemy.pos.col === c && active.pa >= 3) {
         const paCost = 3;
@@ -225,8 +237,6 @@ document.addEventListener('DOMContentLoaded', () => {
 
     if (!cell.classList.contains('reachable')) return;
 
-    const r = Number(cell.dataset.row);
-    const c = Number(cell.dataset.col);
     const dist = computeReachable(active.pos, active.pm, active.allow);
     const path = buildPath(active.pos, { row: r, col: c }, dist, active.allow);
     if (!path) return;

--- a/js/units.js
+++ b/js/units.js
@@ -78,6 +78,8 @@ export function mountUnit(unit) {
   unit.el.style.left = `${x}px`;
   unit.el.style.top = `${y}px`;
   unit.el.style.transform = 'translate(-50%, -50%)';
+  unit.el.dataset.row = String(unit.pos.row);
+  unit.el.dataset.col = String(unit.pos.col);
   if (unit.el.parentElement !== board) board.appendChild(unit.el);
 }
 

--- a/tests/attack.test.js
+++ b/tests/attack.test.js
@@ -1,0 +1,45 @@
+import { jest } from '@jest/globals';
+import { ROWS, COLS } from '../js/board-utils.js';
+import { units, setActiveId } from '../js/units.js';
+import * as ui from '../js/ui.js';
+await import('../js/main.js');
+
+function setupBoard() {
+  document.body.innerHTML = '<div class="page"><div class="board"><div class="grid"></div></div></div>';
+  const grid = document.querySelector('.grid');
+  for (let r = 0; r < ROWS; r++) {
+    for (let c = 0; c < COLS; c++) {
+      const card = document.createElement('div');
+      card.className = `card back ${r < ROWS / 2 ? 'red' : 'blue'}`;
+      grid.appendChild(card);
+    }
+  }
+}
+
+describe('soco attack', () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+    setupBoard();
+    units.blue.pos = { row: 1, col: 0 };
+    units.red.pos = { row: 0, col: 0 };
+    units.blue.pa = 6;
+    units.red.pv = 10;
+    setActiveId('blue');
+    document.dispatchEvent(new Event('DOMContentLoaded'));
+  });
+
+  afterEach(() => {
+    jest.runOnlyPendingTimers();
+    jest.useRealTimers();
+    document.body.innerHTML = '';
+  });
+
+  test('clicking enemy unit consumes PA and deals damage', async () => {
+    ui.uiState.socoSlot.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    units.red.el.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    jest.runAllTimers();
+    await Promise.resolve();
+    expect(units.red.pv).toBe(8);
+    expect(units.blue.pa).toBe(3);
+  });
+});


### PR DESCRIPTION
## Summary
- Track unit board coordinates in DOM `data-row`/`data-col`
- Listen for clicks on the board to resolve target cells or units and trigger attacks
- Test soco attack reduces PA and enemy PV

## Testing
- `node --experimental-vm-modules node_modules/jest/bin/jest.js --runInBand`

------
https://chatgpt.com/codex/tasks/task_e_68a22f852930832ebeeae6e736e5cada