### PR TITLE
Add movement and combat integration tests and timer coverage

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -45,7 +45,7 @@ export async function startBattle() {
   });
 }
 
-async function moveUnitAlongPath(unit, path, cost) {
+export async function moveUnitAlongPath(unit, path, cost) {
   if (path.length < 2) {
     showFloatingText(unit, `-${cost}`, 'pm');
     return;

--- a/tests/moveUnitAlongPath.test.js
+++ b/tests/moveUnitAlongPath.test.js
@@ -1,0 +1,57 @@
+import { jest } from '@jest/globals';
+import { ROWS, COLS } from '../js/board-utils.js';
+const unitsModule = await import('../js/units.js');
+const { moveUnitAlongPath } = await import('../js/main.js');
+
+describe('moveUnitAlongPath', () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+    document.body.innerHTML = '';
+  });
+
+  test('updates unit position and handles a single transition', async () => {
+    const cards = Array.from({ length: ROWS * COLS }, () => document.createElement('div'));
+    cards[5].getBoundingClientRect = () => ({
+      left: 10,
+      top: 20,
+      width: 0,
+      height: 0,
+      right: 10,
+      bottom: 20,
+    });
+    unitsModule.initUnits(cards, () => true, () => true);
+
+    const unit = {
+      pos: { row: 0, col: 0 },
+      x: 0,
+      y: 0,
+      el: document.createElement('div'),
+    };
+    document.body.appendChild(unit.el);
+
+    const addSpy = jest.spyOn(unit.el, 'addEventListener');
+    const path = [
+      { row: 0, col: 0 },
+      { row: 1, col: 1 },
+    ];
+    const promise = moveUnitAlongPath(unit, path, 1);
+    unit.el.dispatchEvent(new Event('transitionend'));
+    await promise;
+
+    expect(unit.pos).toEqual({ row: 1, col: 1 });
+    expect(unit.x).toBe(10);
+    expect(unit.y).toBe(20);
+    expect(unit.el.style.left).toBe('10px');
+    expect(unit.el.style.top).toBe('20px');
+    expect(unit.el.style.transform).toBe('translate(-50%, -50%)');
+
+    const spans = unit.el.querySelectorAll('.float-text.pm');
+    expect(spans).toHaveLength(1);
+    expect(spans[0].textContent).toBe('-1');
+    expect(addSpy).toHaveBeenCalledWith('transitionend', expect.any(Function), { once: true });
+
+    unit.el.dispatchEvent(new Event('transitionend'));
+    expect(unit.el.querySelectorAll('.float-text.pm')).toHaveLength(1);
+  });
+});
+

--- a/tests/punchAttack.integration.test.js
+++ b/tests/punchAttack.integration.test.js
@@ -1,0 +1,53 @@
+import { jest } from '@jest/globals';
+import { ROWS, COLS } from '../js/board-utils.js';
+
+let units;
+let ui;
+
+beforeEach(async () => {
+  jest.useFakeTimers();
+  jest.resetModules();
+  document.body.innerHTML = '<div class="page"><div class="board"><div class="grid"></div></div></div>';
+  const grid = document.querySelector('.grid');
+  for (let i = 0; i < ROWS * COLS; i++) {
+    const card = document.createElement('div');
+    card.className = `card ${i < (ROWS * COLS) / 2 ? 'red' : 'blue'}`;
+    grid.appendChild(card);
+  }
+  units = await import('../js/units.js');
+  ui = await import('../js/ui.js');
+  await import('../js/main.js');
+  document.dispatchEvent(new Event('DOMContentLoaded'));
+
+  units.setActiveId('blue');
+  units.units.blue.pos = { row: 2, col: 2 };
+  units.units.red.pos = { row: 2, col: 3 };
+  units.mountUnit(units.units.blue);
+  units.mountUnit(units.units.red);
+});
+
+afterEach(() => {
+  ui.stopTurnTimer();
+  jest.runOnlyPendingTimers();
+  jest.useRealTimers();
+  document.body.innerHTML = '';
+});
+
+test('punch attack updates PV/PA and renders floating text', async () => {
+  ui.uiState.socoSlot.click();
+  const enemyCard = document.querySelector(`.card[data-row="${units.units.red.pos.row}"][data-col="${units.units.red.pos.col}"]`);
+  expect(enemyCard?.classList.contains('attackable')).toBe(true);
+
+  enemyCard.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+  jest.advanceTimersByTime(600);
+  await Promise.resolve();
+
+  expect(units.units.blue.pa).toBe(3);
+  expect(units.units.red.pv).toBe(8);
+
+  const paText = units.units.blue.el.querySelector('.float-text.pa');
+  const pvText = units.units.red.el.querySelector('.float-text.pv');
+  expect(paText?.textContent).toBe('-3');
+  expect(pvText?.textContent).toBe('-2');
+});
+

--- a/tests/ui.test.js
+++ b/tests/ui.test.js
@@ -1,5 +1,6 @@
 import { jest } from '@jest/globals';
-const { passTurn, stopTurnTimer, startTurnTimer } = await import('../js/ui.js');
+const uiModule = await import('../js/ui.js');
+const { passTurn, stopTurnTimer, startTurnTimer } = uiModule;
 const { units, setActiveId } = await import('../js/units.js');
 const { startBattle } = await import('../js/main.js');
 
@@ -27,6 +28,13 @@ describe('passTurn', () => {
     units.red.pa = 2;
     passTurn();
     expect(units.red.pa).toBe(6);
+  });
+
+  test('refills PM for the unit that ended its turn', () => {
+    setActiveId('blue');
+    units.blue.pm = 0;
+    passTurn();
+    expect(units.blue.pm).toBe(3);
   });
 
   test('displays popup when passing the turn', () => {
@@ -65,4 +73,24 @@ describe('startBattle', () => {
     expect(popup.textContent).toBe('Iniciando turno do jogador azul');
     expect(document.querySelector('.popup-container.top-left')).not.toBeNull();
   }, 10000);
+});
+
+describe('turn timer', () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+  });
+
+  afterEach(() => {
+    stopTurnTimer();
+    jest.runOnlyPendingTimers();
+    jest.useRealTimers();
+  });
+
+  test('automatically passes the turn when time runs out', () => {
+    setActiveId('blue');
+    units.blue.pa = 1;
+    startTurnTimer();
+    jest.advanceTimersByTime(30000);
+    expect(units.blue.pa).toBe(6);
+  });
 });


### PR DESCRIPTION
## Summary
- export moveUnitAlongPath for direct testing
- add tests for unit movement and punch attack flow
- cover turn timer auto-pass and PM refill in passTurn

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a22f8ad26c832e9600fb2d64c77a04