### PR TITLE
Add loot item tooltips

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -123,6 +123,7 @@ export function gameOver(result) {
           const el = document.createElement('div');
           el.className = 'loot-item';
           el.textContent = it.icon || it.id;
+          el.title = it.effect;
 
           // When the player chooses an item we apply its effects, update the
           // UI and then transition back to the map screen advancing the stage.

--- a/tests/gameOver.test.js
+++ b/tests/gameOver.test.js
@@ -19,6 +19,7 @@ describe('gameOver victory chest', () => {
 
   afterEach(() => {
     jest.useRealTimers();
+    jest.restoreAllMocks();
     document.body.innerHTML = '';
   });
 
@@ -40,6 +41,23 @@ describe('gameOver victory chest', () => {
     chest.dispatchEvent(new Event('click'));
     const items = document.querySelectorAll('.loot-item');
     expect(items.length).toBe(3);
+  });
+
+  test('loot items have effect as title attribute', () => {
+    jest
+      .spyOn(Math, 'random')
+      .mockReturnValueOnce(0)
+      .mockReturnValueOnce(0.2)
+      .mockReturnValueOnce(0.4);
+    gameOver('vitoria');
+    jest.advanceTimersByTime(1000);
+    document.querySelector('.chest')?.dispatchEvent(new Event('click'));
+    const items = Array.from(document.querySelectorAll('.loot-item'));
+    expect(items.map(i => i.title)).toEqual([
+      'Cura 2 PV',
+      'Aumenta ataque em 3',
+      'Aumenta ataque em 4',
+    ]);
   });
 
   test('selecting an item applies effect and advances stage', () => {


### PR DESCRIPTION
## Summary
- show item effect in loot selection using native tooltip
- test loot tooltip behaviour

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a23ae707fc832e84ae8f93d2511acf