### PR TITLE
Preserve flex layout when switching screens

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -157,7 +157,7 @@ export function gameOver(result) {
               const boardScreen = document.getElementById('board-screen');
               const mapScreen = document.getElementById('map-screen');
               if (boardScreen) boardScreen.style.display = 'none';
-              if (mapScreen) mapScreen.style.display = 'block';
+              if (mapScreen) mapScreen.style.display = '';
             },
             { once: true },
           );

--- a/js/map.js
+++ b/js/map.js
@@ -58,7 +58,7 @@ if (current) {
 playBtn.addEventListener('click', () => {
   localStorage.setItem(stageKey, stage);
   if (mapScreen) mapScreen.style.display = 'none';
-  if (boardScreen) boardScreen.style.display = 'block';
+  if (boardScreen) boardScreen.style.display = '';
   showOverlay();
   startBattle();
 });

--- a/js/ui.js
+++ b/js/ui.js
@@ -80,7 +80,7 @@ export function gameOver(result) {
         const board = document.getElementById('board-screen');
         const map = document.getElementById('map-screen');
         if (board) board.style.display = 'none';
-        if (map) map.style.display = 'block';
+        if (map) map.style.display = '';
         window.location.reload();
       },
       { once: true },


### PR DESCRIPTION
## Summary
- Ensure map screen restores its flex layout when returning from the board
- Avoid overriding board screen layout when starting a battle
- Keep defeat exit transition from clobbering map layout

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a23d01716c832e867c653115cc3f18