### PR TITLE
Refatora mapa com renderização dinâmica e animações

### DIFF
--- a/css/map.css
+++ b/css/map.css
@@ -20,11 +20,18 @@
   background: #6b7280;
   border: 2px solid #374151;
   box-shadow: 0 2px 4px rgba(0, 0, 0, 0.4);
+  transition: transform 0.3s ease;
 }
 
 .map-node.current {
   background: #10b981;
   border-color: #059669;
+  transform: scale(1.2);
+}
+
+.map-node.past {
+  background: #000;
+  border-color: #111827;
 }
 
 .map-connection {
@@ -36,5 +43,6 @@
 
 .map-play-btn {
   position: absolute;
+  transition: left 0.3s ease, top 0.3s ease;
 }
 

--- a/js/main.js
+++ b/js/main.js
@@ -17,6 +17,7 @@ import * as ui from './ui.js';
 const { initUI, updateBluePanel, initEnemyTooltip, startTurnTimer } = ui;
 import { getRandomItems } from './config.js';
 import { showOverlay, showPopup } from './overlay.js';
+import { renderMap } from './map.js';
 
 export function checkGameOver() {
   if (units.blue.pv <= 0) ui.gameOver('derrota');
@@ -158,6 +159,7 @@ export function gameOver(result) {
               const mapScreen = document.getElementById('map-screen');
               if (boardScreen) boardScreen.style.display = 'none';
               if (mapScreen) mapScreen.style.display = '';
+              renderMap();
             },
             { once: true },
           );

--- a/js/map.js
+++ b/js/map.js
@@ -9,56 +9,74 @@ const path = [
 const stageKey = 'stage';
 const playedKey = 'played';
 
-let stage = Number(localStorage.getItem(stageKey));
-if (Number.isNaN(stage)) {
-  stage = 0;
-}
-
-if (localStorage.getItem(playedKey)) {
-  stage = Number(localStorage.getItem(stageKey)) || stage;
-  localStorage.removeItem(playedKey);
-}
-
-localStorage.setItem(stageKey, stage);
-
 const container = document.getElementById('map');
 const mapScreen = document.getElementById('map-screen');
 const boardScreen = document.getElementById('board-screen');
+const playBtn = document.getElementById('play');
 
-path.forEach((node, idx) => {
-  const el = document.createElement('div');
-  el.className = 'map-node' + (idx === stage ? ' current' : '');
-  el.style.left = `${node.x}px`;
-  el.style.top = `${node.y}px`;
-  container.appendChild(el);
-
-  if (idx > 0) {
-    const prev = path[idx - 1];
-    const conn = document.createElement('div');
-    conn.className = 'map-connection';
-    conn.style.left = `${prev.x + 10}px`;
-    conn.style.top = `${Math.min(prev.y, node.y) + 12}px`;
-    conn.style.height = `${Math.abs(node.y - prev.y)}px`;
-    container.appendChild(conn);
+function getStage() {
+  let stage = Number(localStorage.getItem(stageKey));
+  if (Number.isNaN(stage)) stage = 0;
+  if (localStorage.getItem(playedKey)) {
+    stage = Number(localStorage.getItem(stageKey)) || stage;
+    localStorage.removeItem(playedKey);
   }
-});
+  localStorage.setItem(stageKey, String(stage));
+  return stage;
+}
+
+export function renderMap() {
+  if (!container || !playBtn) return;
+
+  const stage = getStage();
+
+  container
+    .querySelectorAll('.map-node, .map-connection')
+    .forEach(el => el.remove());
+
+  path.forEach((node, idx) => {
+    const el = document.createElement('div');
+    el.className = 'map-node';
+    if (idx === stage) el.classList.add('current');
+    else if (idx < stage) el.classList.add('past');
+    el.style.left = `${node.x}px`;
+    el.style.top = `${node.y}px`;
+    container.appendChild(el);
+
+    if (idx > 0) {
+      const prev = path[idx - 1];
+      const conn = document.createElement('div');
+      conn.className = 'map-connection';
+      conn.style.left = `${prev.x + 10}px`;
+      conn.style.top = `${Math.min(prev.y, node.y) + 12}px`;
+      conn.style.height = `${Math.abs(node.y - prev.y)}px`;
+      container.appendChild(conn);
+    }
+  });
+
+  const current = path[stage];
+  if (current) {
+    playBtn.style.left = `${current.x + 12}px`;
+    playBtn.style.top = `${current.y + 40}px`;
+    playBtn.style.transform = 'translate(-50%, 0)';
+    playBtn.disabled = false;
+    playBtn.style.display = '';
+  } else {
+    playBtn.disabled = true;
+    playBtn.style.display = 'none';
+  }
+}
 
 import { showOverlay, startBattle } from './main.js';
 
-const playBtn = document.getElementById('play');
-const current = path[stage];
-if (current) {
-  playBtn.style.left = `${current.x + 40}px`;
-  playBtn.style.top = `${current.y - 7}px`;
-} else {
-  playBtn.disabled = true;
-  playBtn.style.display = 'none';
-}
+renderMap();
 
-playBtn.addEventListener('click', () => {
-  localStorage.setItem(stageKey, stage);
+playBtn?.addEventListener('click', () => {
+  const stage = Number(localStorage.getItem(stageKey)) || 0;
+  localStorage.setItem(stageKey, String(stage));
   if (mapScreen) mapScreen.style.display = 'none';
   if (boardScreen) boardScreen.style.display = '';
   showOverlay();
   startBattle();
 });
+


### PR DESCRIPTION
## Summary
- Refatora `map.js` para expor `renderMap`, recriar nós e reposicionar o botão conforme o estágio salvo
- Adiciona estilos de progresso (`past`/`current`) e transições no mapa
- Atualiza `main.js` para re-renderizar o mapa ao voltar do tabuleiro

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a23fd07f28832eb2d193b602797fdc