### PR TITLE
feat: add item metadata and inventory logic

### DIFF
--- a/js/config.js
+++ b/js/config.js
@@ -1,8 +1,10 @@
 //
 // Items available as loot in the game. Each entry includes its visual `icon`,
 // action point `paCost`, base `damage`, attack `range`, textual `effect`
-// description and an optional `extraAttack` flag. Every item exposes an
-// `apply` function that mutates the provided unit.
+// description and two metadata flags: `usable` indicates whether the item can
+// be stored in a slot for later use and `consumable` defines if it is removed
+// once used. Every item exposes an `apply` function that mutates the provided
+// unit.
 //
 export const itemsConfig = [
   {
@@ -12,6 +14,8 @@ export const itemsConfig = [
     damage: 0,
     range: 0,
     effect: 'Cura 2 PV',
+    consumable: true,
+    usable: false,
     apply(unit) {
       unit.pv += 2;
     },
@@ -23,10 +27,11 @@ export const itemsConfig = [
     damage: 3,
     range: 1,
     effect: 'Aumenta ataque em 3',
+    consumable: false,
+    usable: true,
     apply(unit) {
       unit.attack = (unit.attack || 0) + 3;
     },
-    extraAttack: true,
   },
   {
     id: 'martelo',
@@ -35,6 +40,8 @@ export const itemsConfig = [
     damage: 4,
     range: 1,
     effect: 'Aumenta ataque em 4',
+    consumable: false,
+    usable: true,
     apply(unit) {
       unit.attack = (unit.attack || 0) + 4;
     },
@@ -46,6 +53,8 @@ export const itemsConfig = [
     damage: 5,
     range: 2,
     effect: 'Causa 5 de dano',
+    consumable: true,
+    usable: true,
     apply(unit) {
       unit.pv -= 5;
     },
@@ -57,6 +66,8 @@ export const itemsConfig = [
     damage: 0,
     range: 0,
     effect: 'Aumenta PV em 3',
+    consumable: false,
+    usable: true,
     apply(unit) {
       unit.pv += 3;
     },
@@ -68,6 +79,8 @@ export const itemsConfig = [
     damage: 0,
     range: 0,
     effect: 'Restaura 2 PA',
+    consumable: true,
+    usable: false,
     apply(unit) {
       unit.pa += 2;
     },

--- a/js/main.js
+++ b/js/main.js
@@ -126,27 +126,17 @@ export function gameOver(result) {
           el.textContent = it.icon || it.id;
           el.title = it.effect;
 
-          // When the player chooses an item we apply its effects, update the
-          // UI and then transition back to the map screen advancing the stage.
+          // When the player chooses an item we either consume it immediately or
+          // move it to an inventory slot, then transition back to the map
+          // screen advancing the stage.
           el.addEventListener(
             'click',
             () => {
-              it.apply?.(units.blue);
-              updateBluePanel(units.blue);
-
-              // If the item grants an additional attack, append a card to the
-              // turn panel so the player can use it on the next battle.
-              if (it.extraAttack) {
-                const slots = document.querySelector('.turn-panel .slots');
-                const empty = Array.from(slots?.children || []).find(
-                  s => s.children.length === 0,
-                );
-                if (empty) {
-                  const card = document.createElement('div');
-                  card.className = 'card-extra';
-                  card.textContent = it.icon || it.id;
-                  empty.appendChild(card);
-                }
+              if (it.consumable && !it.usable) {
+                it.apply?.(units.blue);
+                updateBluePanel(units.blue);
+              } else if (it.usable) {
+                ui.addItemCard(it);
               }
 
               // Advance stage and show the map screen again

--- a/js/ui.js
+++ b/js/ui.js
@@ -176,6 +176,29 @@ export function initUI() {
   passBtn.addEventListener('click', passTurn);
 }
 
+export function addItemCard(item) {
+  const slots = document.querySelector('.turn-panel .slots');
+  const empty = Array.from(slots?.children || []).find(
+    s => s.children.length === 0,
+  );
+  if (!empty) return;
+
+  const card = document.createElement('div');
+  card.className = 'card-item';
+  card.textContent = item.icon || item.id;
+  card.title = item.effect;
+
+  card.addEventListener('click', () => {
+    item.apply?.(units.blue);
+    updateBluePanel(units.blue);
+    if (item.consumable) {
+      card.remove();
+    }
+  });
+
+  empty.appendChild(card);
+}
+
 export function initEnemyTooltip() {
   const enemyTooltip = document.createElement('div');
   enemyTooltip.className = 'enemy-tooltip';

--- a/tests/gameOver.test.js
+++ b/tests/gameOver.test.js
@@ -60,7 +60,7 @@ describe('gameOver victory chest', () => {
     ]);
   });
 
-  test('selecting an item applies effect and advances stage', () => {
+  test('selecting a consumable item applies effect and advances stage', () => {
     // Ensure deterministic loot: pick the coffee item to restore PA
     jest.spyOn(Math, 'random').mockReturnValue(0.95);
     units.blue.pa = 6;
@@ -72,5 +72,44 @@ describe('gameOver victory chest', () => {
     expect(localStorage.getItem('stage')).toBe('1');
     const paEl = document.querySelector('.pa');
     expect(paEl?.textContent).toBe('8');
+    const slots = document.querySelectorAll('.slot');
+    expect(slots[1].children.length).toBe(0);
+  });
+
+  test('selecting a usable item stores it in a slot and can be used later', () => {
+    jest.spyOn(Math, 'random').mockReturnValue(0.2);
+    gameOver('vitoria');
+    jest.advanceTimersByTime(1000);
+    document.querySelector('.chest')?.dispatchEvent(new Event('click'));
+    const lootItem = document.querySelector('.loot-item');
+    lootItem?.dispatchEvent(new Event('click'));
+
+    const slots = document.querySelectorAll('.slot');
+    const card = slots[1].firstElementChild;
+    expect(card?.textContent).toBe('🗡️');
+    expect(units.blue.attack).toBeUndefined();
+
+    card?.dispatchEvent(new Event('click'));
+    expect(units.blue.attack).toBe(3);
+    // sword is not consumable, so card remains
+    expect(slots[1].children.length).toBe(1);
+  });
+
+  test('using a consumable card removes it from the slot', () => {
+    jest.spyOn(Math, 'random').mockReturnValue(0.55);
+    gameOver('vitoria');
+    jest.advanceTimersByTime(1000);
+    document.querySelector('.chest')?.dispatchEvent(new Event('click'));
+    const lootItem = document.querySelector('.loot-item');
+    lootItem?.dispatchEvent(new Event('click'));
+
+    const slots = document.querySelectorAll('.slot');
+    const card = slots[1].firstElementChild;
+    expect(card?.textContent).toBe('💣');
+
+    units.blue.pv = 10;
+    card?.dispatchEvent(new Event('click'));
+    expect(units.blue.pv).toBe(5);
+    expect(slots[1].children.length).toBe(0);
   });
 });

--- a/tests/items.test.js
+++ b/tests/items.test.js
@@ -13,9 +13,8 @@ describe('itemsConfig configuration', () => {
       expect(typeof it.range).toBe('number');
       expect(typeof it.effect).toBe('string');
       expect(typeof it.apply).toBe('function');
-      if (it.extraAttack !== undefined) {
-        expect(typeof it.extraAttack).toBe('boolean');
-      }
+      expect(typeof it.usable).toBe('boolean');
+      expect(typeof it.consumable).toBe('boolean');
     }
   });
 


### PR DESCRIPTION
## Summary
- annotate loot items with `usable` and `consumable` flags
- handle consumables and inventory slots when looting
- allow slot cards to apply effects and vanish if consumable
- expand tests for inventory and item consumption

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a2b672d7e4832eb3d18bdf8c275d89