### PR TITLE
Reset battle state before restarting battles

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -10,11 +10,12 @@ import {
   clearSocoAlcance,
   showFloatingText,
   getCoords,
+  resetUnits,
 } from './units.js';
 
 import * as ui from './ui.js';
 
-const { initUI, updateBluePanel, initEnemyTooltip, startTurnTimer } = ui;
+const { initUI, updateBluePanel, initEnemyTooltip, startTurnTimer, resetUI } = ui;
 import { getRandomItems } from './config.js';
 import { showOverlay, showPopup } from './overlay.js';
 import { renderMap } from './map.js';
@@ -25,6 +26,9 @@ export function checkGameOver() {
 }
 
 export async function startBattle() {
+  document.querySelectorAll('.chest, .loot').forEach(el => el.remove());
+  resetUnits();
+  resetUI();
   // Recalcula a posição das unidades após o tabuleiro ficar visível. Caso os
   // elementos sejam montados enquanto o tabuleiro está oculto (`display: none`),
   // `getBoundingClientRect` retorna dimensões zero e as unidades desaparecem.

--- a/js/ui.js
+++ b/js/ui.js
@@ -199,6 +199,22 @@ export function addItemCard(item) {
   empty.appendChild(card);
 }
 
+export function resetUI() {
+  const slots = document.querySelectorAll('.turn-panel .slot');
+  slots.forEach((slot, idx) => {
+    if (idx === 0) {
+      const soco = slot.querySelector('.card-soco');
+      slot.innerHTML = '';
+      if (soco) slot.appendChild(soco);
+      slot.classList.remove('is-selected');
+    } else {
+      slot.innerHTML = '';
+    }
+  });
+  uiState.socoSelecionado = false;
+  updateBluePanel(units.blue);
+}
+
 export function initEnemyTooltip() {
   const enemyTooltip = document.createElement('div');
   enemyTooltip.className = 'enemy-tooltip';

--- a/js/units.js
+++ b/js/units.js
@@ -49,6 +49,22 @@ export function initUnits(cardEls, isBlue, isRed) {
   reflectActiveStyles();
 }
 
+export function resetUnits() {
+  units.blue.pos = { row: 5, col: 3 };
+  units.blue.pv = 10;
+  units.blue.pm = 3;
+  units.blue.pa = 6;
+  units.red.pos = { row: 0, col: 0 };
+  units.red.pv = 10;
+  units.red.pm = 3;
+  units.red.pa = 6;
+  Object.values(units).forEach(u => {
+    u.el?.remove();
+    u.el = createUnitEl(u.id);
+  });
+  setActiveId('blue');
+}
+
 export function createUnitEl(id) {
   const el = document.createElement('div');
   el.className = `unit unit-${id}`;

--- a/tests/main.test.js
+++ b/tests/main.test.js
@@ -3,7 +3,7 @@ import { jest } from '@jest/globals';
 const ui = await import('../js/ui.js');
 const { passTurn, stopTurnTimer } = ui;
 const { units, setActiveId } = await import('../js/units.js');
-const { checkGameOver } = await import('../js/main.js');
+const { checkGameOver, gameOver, startBattle } = await import('../js/main.js');
 
 describe('game over logic', () => {
   beforeEach(() => {
@@ -55,5 +55,24 @@ describe('game over logic', () => {
     const btn = overlay?.querySelector('button');
     expect(btn?.textContent).toBe('Sair');
   });
+
+  test('startBattle removes chest and loot after victory', async () => {
+    document.body.innerHTML = '<div class="board"></div>';
+    gameOver('vitoria');
+    jest.advanceTimersByTime(1000);
+    const chest = document.querySelector('.chest');
+    expect(chest).not.toBeNull();
+    chest?.dispatchEvent(new Event('click'));
+    expect(document.querySelector('.loot')).not.toBeNull();
+    const p = startBattle();
+    expect(document.querySelector('.chest')).toBeNull();
+    expect(document.querySelector('.loot')).toBeNull();
+    for (let i = 0; i < 3; i++) {
+      jest.advanceTimersByTime(1000);
+      await Promise.resolve();
+    }
+    await p;
+    jest.runOnlyPendingTimers();
+  }, 10000);
 });
 

--- a/tests/moveUnitAlongPath.test.js
+++ b/tests/moveUnitAlongPath.test.js
@@ -13,6 +13,7 @@ jest.unstable_mockModule('../js/units.js', () => ({
   clearSocoAlcance: jest.fn(),
   showFloatingText,
   getCoords,
+  resetUnits: jest.fn(),
 }));
 
 jest.unstable_mockModule('../js/ui.js', () => ({

--- a/tests/ui.test.js
+++ b/tests/ui.test.js
@@ -1,7 +1,7 @@
 import { jest } from '@jest/globals';
-const { passTurn, stopTurnTimer, startTurnTimer } = await import('../js/ui.js');
+const { passTurn, stopTurnTimer, startTurnTimer, initUI, addItemCard, uiState } = await import('../js/ui.js');
 const { units, setActiveId } = await import('../js/units.js');
-const { startBattle } = await import('../js/main.js');
+const { startBattle, gameOver } = await import('../js/main.js');
 
 describe('passTurn', () => {
   beforeEach(() => {
@@ -64,5 +64,28 @@ describe('startBattle', () => {
     expect(popup).not.toBeNull();
     expect(popup.textContent).toBe('Iniciando turno do jogador azul');
     expect(document.querySelector('.popup-container.top-left')).not.toBeNull();
+  }, 10000);
+
+  test('startBattle resets UI after game over', async () => {
+    jest.useFakeTimers();
+    document.body.innerHTML = '<div class="page"></div>';
+    initUI();
+    addItemCard({ id: 'x', icon: 'x', effect: '', consumable: true });
+    uiState.socoSlot.classList.add('is-selected');
+    uiState.socoSelecionado = true;
+    gameOver('vitoria');
+    jest.advanceTimersByTime(1000);
+    const p = startBattle();
+    const slots = document.querySelectorAll('.turn-panel .slot');
+    expect(slots[0].children.length).toBe(1);
+    expect(slots[0].classList.contains('is-selected')).toBe(false);
+    expect(slots[1].children.length).toBe(0);
+    for (let i = 0; i < 3; i++) {
+      jest.advanceTimersByTime(1000);
+      await Promise.resolve();
+    }
+    await p;
+    jest.runOnlyPendingTimers();
+    jest.useRealTimers();
   }, 10000);
 });


### PR DESCRIPTION
## Summary
- Remove leftover chest and loot elements before a new battle
- Reset unit stats and UI panel when restarting a battle
- Add tests ensuring board and UI are clean after restarting

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a2bba0f2c0832ea11ecb69152b3657