### PR TITLE
Corrige movimentação das unidades ao reiniciar batalha

### DIFF
--- a/js/units.js
+++ b/js/units.js
@@ -61,6 +61,10 @@ export function resetUnits() {
   Object.values(units).forEach(u => {
     u.el?.remove();
     u.el = createUnitEl(u.id);
+    u.el.addEventListener('mouseenter', () => {
+      if (getActive().id !== u.id) return;
+      showReachableFor(u);
+    });
   });
   setActiveId('blue');
 }

--- a/tests/units.test.js
+++ b/tests/units.test.js
@@ -1,4 +1,6 @@
+import { jest } from '@jest/globals';
 import { ROWS, COLS } from '../js/board-utils.js';
+import * as unitsModule from '../js/units.js';
 import {
   units,
   initUnits,
@@ -8,6 +10,7 @@ import {
   showReachableFor,
   showSocoAlcance,
   showFloatingText,
+  resetUnits,
 } from '../js/units.js';
 
 function createCards() {
@@ -70,6 +73,13 @@ describe('units module', () => {
 
     span.dispatchEvent(new Event('animationend'));
     expect(parent.querySelector('span.float-text.test')).toBeNull();
+  });
+
+  test('resetUnits reattaches hover listeners', () => {
+    resetUnits();
+    units.blue.el.dispatchEvent(new Event('mouseenter'));
+    const hasReachable = cards.some(c => c.classList.contains('reachable'));
+    expect(hasReachable).toBe(true);
   });
 });
 


### PR DESCRIPTION
## Summary
- Reanexa o listener de `mouseenter` às unidades ao resetar, garantindo que as casas alcançáveis sejam destacadas
- Adiciona teste para assegurar que o reset volta a habilitar o destaque de movimento

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a34ef0ebd8832eaa12ad2e70f8d750