### PR TITLE
Add PA cost and usability to heart item

### DIFF
--- a/js/config.js
+++ b/js/config.js
@@ -10,14 +10,15 @@ export const itemsConfig = [
   {
     id: 'vida+2',
     icon: '💖',
-    paCost: 0,
+    paCost: 1,
     damage: 0,
     range: 0,
     effect: 'Cura 2 PV',
     consumable: true,
-    usable: false,
+    usable: true,
     apply(unit) {
-      unit.pv += 2;
+      unit.pa -= 1;
+      unit.pv = Math.min(unit.pv + 2, unit.maxPv || 10);
     },
   },
   {

--- a/js/ui.js
+++ b/js/ui.js
@@ -189,6 +189,9 @@ export function addItemCard(item) {
   card.title = item.effect;
 
   card.addEventListener('click', () => {
+    if (units.blue.pa < item.paCost) return;
+    units.blue.pa -= item.paCost;
+    updateBluePanel(units.blue);
     item.apply?.(units.blue);
     updateBluePanel(units.blue);
     if (item.consumable) {

--- a/tests/items.test.js
+++ b/tests/items.test.js
@@ -22,9 +22,10 @@ describe('itemsConfig configuration', () => {
     const base = { pv: 10, pa: 5, attack: 1 };
     const find = id => itemsConfig.find(i => i.id === id);
 
-    const u1 = { ...base };
-    find('vida+2').apply(u1);
-    expect(u1.pv).toBe(12);
+    const heartTarget = { pv: 8, pa: 5 };
+    find('vida+2').apply(heartTarget);
+    expect(heartTarget.pv).toBe(10);
+    expect(heartTarget.pa).toBe(4);
 
     const u2 = { ...base };
     find('espada').apply(u2);


### PR DESCRIPTION
## Summary
- Make heart item usable with PA cost and capped healing
- Verify and deduct item PA cost before use in UI
- Update tests for heart item PA usage

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a3948b7054832e98fe962027b337a3