### PR TITLE
Enable attack item selection

### DIFF
--- a/js/config.js
+++ b/js/config.js
@@ -30,9 +30,10 @@ export const itemsConfig = [
     effect: 'Aumenta ataque em 3',
     consumable: false,
     usable: true,
-    apply(unit) {
-      unit.attack = (unit.attack || 0) + 3;
-    },
+    type: 'attack',
+    // This item no longer alters permanent stats. Damage is applied
+    // dynamically when the attack is performed.
+    apply() {},
   },
   {
     id: 'martelo',

--- a/js/main.js
+++ b/js/main.js
@@ -8,6 +8,7 @@ import {
   showReachableFor,
   mountUnit,
   clearSocoAlcance,
+  clearItemAlcance,
   showFloatingText,
   getCoords,
   resetUnits,
@@ -222,6 +223,27 @@ document.addEventListener('DOMContentLoaded', () => {
     if (!cell || r === undefined || c === undefined) return;
 
     const active = getActive();
+    const selected = ui.uiState.selectedItem;
+    if (selected && cell.classList.contains('attackable')) {
+      const enemy = getInactive();
+      const { item, card } = selected;
+      if (
+        enemy.pos.row === r &&
+        enemy.pos.col === c &&
+        active.pa >= item.paCost
+      ) {
+        active.pa -= item.paCost;
+        enemy.pv -= item.damage;
+        await animateAttack(active, enemy, item.paCost, item.damage);
+        updateBluePanel(units.blue);
+        mountUnit(enemy);
+        checkGameOver();
+      }
+      card.classList.remove('is-selected');
+      ui.uiState.selectedItem = null;
+      clearItemAlcance();
+      return;
+    }
     if (ui.uiState.socoSelecionado && cell.classList.contains('attackable')) {
       const enemy = getInactive();
       if (enemy.pos.row === r && enemy.pos.col === c && active.pa >= 3) {

--- a/js/ui.js
+++ b/js/ui.js
@@ -5,6 +5,8 @@ import {
   clearReachable,
   showSocoAlcance as showSocoAlcanceUnits,
   clearSocoAlcance as clearSocoAlcanceUnits,
+  showItemAlcance as showItemAlcanceUnits,
+  clearItemAlcance as clearItemAlcanceUnits,
 } from './units.js';
 import { showOverlay, showPopup } from './overlay.js';
 import { checkGameOver } from './main.js';
@@ -12,6 +14,7 @@ import { checkGameOver } from './main.js';
 export const uiState = {
   socoSlot: null,
   socoSelecionado: false,
+  selectedItem: null,
 };
 
 function showSocoAlcance() {
@@ -21,6 +24,15 @@ function showSocoAlcance() {
 
 function clearSocoAlcance() {
   clearSocoAlcanceUnits();
+}
+
+function showItemAlcance(item) {
+  const active = getActive();
+  showItemAlcanceUnits(active, item);
+}
+
+function clearItemAlcance() {
+  clearItemAlcanceUnits();
 }
 
 let bluePanelRefs = null;
@@ -102,6 +114,9 @@ export function passTurn() {
     duration: 1000,
   });
   clearReachable();
+  uiState.selectedItem?.card?.classList.remove('is-selected');
+  uiState.selectedItem = null;
+  clearItemAlcance();
   updateBluePanel(units.blue);
   checkGameOver();
   if (units.blue.pv > 0 && units.red.pv > 0) {
@@ -189,6 +204,20 @@ export function addItemCard(item) {
   card.title = item.effect;
 
   card.addEventListener('click', () => {
+    if (getActive().id !== 'blue') return;
+    if (item.type === 'attack' && !item.consumable) {
+      if (uiState.selectedItem?.card === card) {
+        card.classList.remove('is-selected');
+        uiState.selectedItem = null;
+        clearItemAlcance();
+      } else {
+        uiState.selectedItem?.card?.classList.remove('is-selected');
+        uiState.selectedItem = { item, card };
+        card.classList.add('is-selected');
+        showItemAlcance(item);
+      }
+      return;
+    }
     if (units.blue.pa < item.paCost) return;
     units.blue.pa -= item.paCost;
     updateBluePanel(units.blue);
@@ -215,6 +244,9 @@ export function resetUI() {
     }
   });
   uiState.socoSelecionado = false;
+  uiState.selectedItem?.card?.classList.remove('is-selected');
+  uiState.selectedItem = null;
+  clearItemAlcance();
   updateBluePanel(units.blue);
 }
 

--- a/js/units.js
+++ b/js/units.js
@@ -154,6 +154,31 @@ export function showSocoAlcance(unit) {
   });
 }
 
+export function clearItemAlcance() {
+  cards.forEach(c => c.classList.remove('attackable'));
+}
+
+export function showItemAlcance(unit, item) {
+  clearItemAlcance();
+  const { row, col } = unit.pos;
+  const deltas = [
+    [-1, 0],
+    [1, 0],
+    [0, -1],
+    [0, 1],
+  ];
+  deltas.forEach(([dr, dc]) => {
+    for (let i = 1; i <= item.range; i++) {
+      const r = row + dr * i;
+      const c = col + dc * i;
+      if (!isInside(r, c)) break;
+      const idx = rowColToIndex(r, c);
+      const card = cards[idx];
+      if (card) card.classList.add('attackable');
+    }
+  });
+}
+
 export function showFloatingText(target, text, className = '') {
   const el = target?.el ?? target;
   if (!el) return;

--- a/tests/gameOver.test.js
+++ b/tests/gameOver.test.js
@@ -89,9 +89,14 @@ describe('gameOver victory chest', () => {
     expect(card?.textContent).toBe('🗡️');
     expect(units.blue.attack).toBeUndefined();
 
+    // Clicking the card toggles selection but does not change stats
     card?.dispatchEvent(new Event('click'));
-    expect(units.blue.attack).toBe(3);
-    // sword is not consumable, so card remains
+    expect(units.blue.attack).toBeUndefined();
+    expect(ui.uiState.selectedItem?.item.id).toBe('espada');
+
+    // Deselecting keeps the card for later use
+    card?.dispatchEvent(new Event('click'));
+    expect(ui.uiState.selectedItem).toBeNull();
     expect(slots[1].children.length).toBe(1);
   });
 

--- a/tests/items.test.js
+++ b/tests/items.test.js
@@ -27,10 +27,6 @@ describe('itemsConfig configuration', () => {
     expect(heartTarget.pv).toBe(10);
     expect(heartTarget.pa).toBe(4);
 
-    const u2 = { ...base };
-    find('espada').apply(u2);
-    expect(u2.attack).toBe(base.attack + 3);
-
     const u3 = { ...base };
     find('cafe').apply(u3);
     expect(u3.pa).toBe(base.pa + 2);
@@ -38,5 +34,17 @@ describe('itemsConfig configuration', () => {
     const u4 = { ...base };
     find('bomba').apply(u4);
     expect(u4.pv).toBe(base.pv - 5);
+  });
+
+  test('sword attack deals damage without altering attacker stats', () => {
+    const sword = itemsConfig.find(i => i.id === 'espada');
+    const attacker = { attack: 1, pa: 6 };
+    const enemy = { pv: 10 };
+    sword.apply(attacker);
+    attacker.pa -= sword.paCost;
+    enemy.pv -= sword.damage;
+    expect(enemy.pv).toBe(7);
+    expect(attacker.attack).toBe(1);
+    expect(attacker.pa).toBe(4);
   });
 });

--- a/tests/moveUnitAlongPath.test.js
+++ b/tests/moveUnitAlongPath.test.js
@@ -11,6 +11,7 @@ jest.unstable_mockModule('../js/units.js', () => ({
   showReachableFor: jest.fn(),
   mountUnit: jest.fn(),
   clearSocoAlcance: jest.fn(),
+  clearItemAlcance: jest.fn(),
   showFloatingText,
   getCoords,
   resetUnits: jest.fn(),


### PR DESCRIPTION
## Summary
- mark sword as non-stat-changing attack item
- allow selecting attack cards to show range and trigger attacks
- ensure attack tests reflect new item behavior

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a39722e988832ebb494f20527ef9af