### PR TITLE
Implement cross-pattern bomb attack

### DIFF
--- a/js/config.js
+++ b/js/config.js
@@ -54,10 +54,12 @@ export const itemsConfig = [
     icon: '💣',
     paCost: 4,
     damage: 5,
-    range: 2,
+    range: 3,
     effect: 'Causa 5 de dano',
     consumable: true,
     usable: true,
+    type: 'attack',
+    pattern: 'cross',
     apply(unit) {
       unit.pv -= 5;
     },

--- a/js/main.js
+++ b/js/main.js
@@ -13,6 +13,7 @@ import {
   getCoords,
   resetUnits,
   getTPatternCells,
+  getCrossPatternCells,
 } from './units.js';
 
 import * as ui from './ui.js';
@@ -241,6 +242,24 @@ document.addEventListener('DOMContentLoaded', () => {
           mountUnit(enemy);
           checkGameOver();
         }
+      } else if (item.pattern === 'cross') {
+        if (active.pa >= item.paCost) {
+          const cells = getCrossPatternCells({ row: r, col: c });
+          active.pa -= item.paCost;
+          showFloatingText(active, `-${item.paCost}`, 'pa');
+          [units.blue, units.red].forEach(u => {
+            if (
+              cells.some(p => p.row === u.pos.row && p.col === u.pos.col)
+            ) {
+              u.pv -= item.damage;
+              showFloatingText(u, `-${item.damage}`, 'pv');
+            }
+          });
+          updateBluePanel(units.blue);
+          mountUnit(units.red);
+          mountUnit(units.blue);
+          checkGameOver();
+        }
       } else if (
         enemy.pos.row === r &&
         enemy.pos.col === c &&
@@ -253,6 +272,7 @@ document.addEventListener('DOMContentLoaded', () => {
         mountUnit(enemy);
         checkGameOver();
       }
+      if (item.consumable) card.remove();
       card.classList.remove('is-selected');
       ui.uiState.selectedItem = null;
       clearItemAlcance();

--- a/js/ui.js
+++ b/js/ui.js
@@ -205,7 +205,7 @@ export function addItemCard(item) {
 
   card.addEventListener('click', () => {
     if (getActive().id !== 'blue') return;
-    if (item.type === 'attack' && !item.consumable) {
+    if (item.type === 'attack') {
       if (uiState.selectedItem?.card === card) {
         card.classList.remove('is-selected');
         uiState.selectedItem = null;

--- a/js/units.js
+++ b/js/units.js
@@ -206,6 +206,24 @@ export function getTPatternCells(unit, enemy) {
   return cells;
 }
 
+export function getCrossPatternCells(center) {
+  const { row, col } = center;
+  const deltas = [
+    [0, 0],
+    [-1, 0],
+    [1, 0],
+    [0, -1],
+    [0, 1],
+  ];
+  const cells = [];
+  deltas.forEach(([dr, dc]) => {
+    const r = row + dr;
+    const c = col + dc;
+    if (isInside(r, c)) cells.push({ row: r, col: c });
+  });
+  return cells;
+}
+
 export function showItemAlcance(unit, item) {
   clearItemAlcance();
   if (item.pattern === 'T') {
@@ -216,6 +234,20 @@ export function showItemAlcance(unit, item) {
       const card = cards[idx];
       if (card) card.classList.add('attackable');
     });
+    return;
+  }
+  if (item.pattern === 'cross') {
+    const { row, col } = unit.pos;
+    for (let r = 0; r < ROWS; r++) {
+      for (let c = 0; c < COLS; c++) {
+        const d = Math.abs(r - row) + Math.abs(c - col);
+        if (d <= item.range) {
+          const idx = rowColToIndex(r, c);
+          const card = cards[idx];
+          if (card) card.classList.add('attackable');
+        }
+      }
+    }
     return;
   }
 

--- a/tests/gameOver.test.js
+++ b/tests/gameOver.test.js
@@ -101,7 +101,7 @@ describe('gameOver victory chest', () => {
   });
 
   test('using a consumable card removes it from the slot', () => {
-    jest.spyOn(Math, 'random').mockReturnValue(0.55);
+    jest.spyOn(Math, 'random').mockReturnValue(0.05);
     gameOver('vitoria');
     jest.advanceTimersByTime(1000);
     document.querySelector('.chest')?.dispatchEvent(new Event('click'));
@@ -110,11 +110,11 @@ describe('gameOver victory chest', () => {
 
     const slots = document.querySelectorAll('.slot');
     const card = slots[1].firstElementChild;
-    expect(card?.textContent).toBe('💣');
+    expect(card?.textContent).toBe('💖');
 
-    units.blue.pv = 10;
+    units.blue.pv = 8;
     card?.dispatchEvent(new Event('click'));
-    expect(units.blue.pv).toBe(5);
+    expect(units.blue.pv).toBe(10);
     expect(slots[1].children.length).toBe(0);
   });
 });

--- a/tests/items.test.js
+++ b/tests/items.test.js
@@ -1,5 +1,5 @@
 import { itemsConfig } from '../js/config.js';
-import { getTPatternCells } from '../js/units.js';
+import { getTPatternCells, getCrossPatternCells } from '../js/units.js';
 
 describe('itemsConfig configuration', () => {
   test('items array contains six objects with required properties', () => {
@@ -70,5 +70,29 @@ describe('itemsConfig configuration', () => {
     attacker.pa -= hammer.paCost;
     expect(enemy.pv).toBe(7);
     expect(attacker.pa).toBe(3);
+  });
+
+  test('bomb affects cross area and is consumable', () => {
+    const bomb = itemsConfig.find(i => i.id === 'bomba');
+    const center = { row: 2, col: 2 };
+    const cells = getCrossPatternCells(center);
+    const targets = [
+      { pos: { row: 2, col: 2 }, pv: 10 },
+      { pos: { row: 1, col: 2 }, pv: 10 },
+      { pos: { row: 2, col: 3 }, pv: 10 },
+      { pos: { row: 5, col: 5 }, pv: 10 },
+    ];
+    cells.forEach(cell => {
+      targets.forEach(t => {
+        if (t.pos.row === cell.row && t.pos.col === cell.col) {
+          bomb.apply(t);
+        }
+      });
+    });
+    expect(targets[0].pv).toBe(5);
+    expect(targets[1].pv).toBe(5);
+    expect(targets[2].pv).toBe(5);
+    expect(targets[3].pv).toBe(10);
+    expect(bomb.consumable).toBe(true);
   });
 });

--- a/tests/moveUnitAlongPath.test.js
+++ b/tests/moveUnitAlongPath.test.js
@@ -16,6 +16,7 @@ jest.unstable_mockModule('../js/units.js', () => ({
   getCoords,
   resetUnits: jest.fn(),
   getTPatternCells: jest.fn(() => []),
+  getCrossPatternCells: jest.fn(() => []),
 }));
 
 jest.unstable_mockModule('../js/ui.js', () => ({


### PR DESCRIPTION
## Summary
- support cross-pattern bomb attack with range 3 and consumable card
- highlight selectable tiles and compute cross area for bomb damage
- ensure attack items, including bombs, can be selected and remove consumables after use

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a39a9c30dc832ebd7408489af24677