### PR TITLE
chore: remove coffee item

### DIFF
--- a/js/config.js
+++ b/js/config.js
@@ -77,19 +77,6 @@ export const itemsConfig = [
       unit.pv += 3;
     },
   },
-  {
-    id: 'cafe',
-    icon: '☕',
-    paCost: 0,
-    damage: 0,
-    range: 0,
-    effect: 'Restaura 2 PA',
-    consumable: true,
-    usable: false,
-    apply(unit) {
-      unit.pa += 2;
-    },
-  },
 ];
 
 export function getRandomItems(count = 1) {

--- a/tests/gameOver.test.js
+++ b/tests/gameOver.test.js
@@ -60,20 +60,18 @@ describe('gameOver victory chest', () => {
     ]);
   });
 
-  test('selecting a consumable item applies effect and advances stage', () => {
-    // Ensure deterministic loot: pick the coffee item to restore PA
-    jest.spyOn(Math, 'random').mockReturnValue(0.95);
-    units.blue.pa = 6;
+  test('selecting a consumable item stores it and advances stage', () => {
+    // Ensure deterministic loot: pick the healing item
+    jest.spyOn(Math, 'random').mockReturnValue(0);
+    units.blue.pv = 8;
     gameOver('vitoria');
     jest.advanceTimersByTime(1000);
     document.querySelector('.chest')?.dispatchEvent(new Event('click'));
     const lootItem = document.querySelector('.loot-item');
     lootItem?.dispatchEvent(new Event('click'));
     expect(localStorage.getItem('stage')).toBe('1');
-    const paEl = document.querySelector('.pa');
-    expect(paEl?.textContent).toBe('8');
     const slots = document.querySelectorAll('.slot');
-    expect(slots[1].children.length).toBe(0);
+    expect(slots[1].children.length).toBe(1);
   });
 
   test('selecting a usable item stores it in a slot and can be used later', () => {

--- a/tests/items.test.js
+++ b/tests/items.test.js
@@ -2,9 +2,9 @@ import { itemsConfig } from '../js/config.js';
 import { getTPatternCells, getCrossPatternCells } from '../js/units.js';
 
 describe('itemsConfig configuration', () => {
-  test('items array contains six objects with required properties', () => {
+  test('items array contains five objects with required properties', () => {
     expect(Array.isArray(itemsConfig)).toBe(true);
-    expect(itemsConfig).toHaveLength(6);
+    expect(itemsConfig).toHaveLength(5);
 
     for (const it of itemsConfig) {
       expect(typeof it.id).toBe('string');
@@ -28,10 +28,6 @@ describe('itemsConfig configuration', () => {
     find('vida+2').apply(heartTarget);
     expect(heartTarget.pv).toBe(10);
     expect(heartTarget.pa).toBe(4);
-
-    const u3 = { ...base };
-    find('cafe').apply(u3);
-    expect(u3.pa).toBe(base.pa + 2);
 
     const u4 = { ...base };
     find('bomba').apply(u4);


### PR DESCRIPTION
## Summary
- drop the coffee item from items configuration and keep random selection logic working
- fix item tests for new array size and remove coffee-specific checks
- adjust victory chest test to store a healing item and advance stage

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a39cc15e90832e919b9a7c6acefe68