### PR TITLE
Add max PV stat and shield upgrade

### DIFF
--- a/js/config.js
+++ b/js/config.js
@@ -70,11 +70,11 @@ export const itemsConfig = [
     paCost: 0,
     damage: 0,
     range: 0,
-    effect: 'Aumenta PV em 3',
-    consumable: false,
-    usable: true,
+    effect: 'Aumenta PV máximo em 3',
+    consumable: true,
+    usable: false,
     apply(unit) {
-      unit.pv += 3;
+      unit.maxPv = (unit.maxPv ?? 10) + 3;
     },
   },
 ];

--- a/js/ui.js
+++ b/js/ui.js
@@ -40,6 +40,7 @@ let bluePanelRefs = null;
 export function updateBluePanel(state) {
   if (!bluePanelRefs) return;
   bluePanelRefs.pv.textContent = `${state.pv}`;
+  bluePanelRefs.maxPv.textContent = `${state.maxPv}`;
   bluePanelRefs.pa.textContent = `${state.pa}`;
   bluePanelRefs.pm.textContent = `${state.pm}`;
 }
@@ -160,7 +161,7 @@ export function initUI() {
   const metrics = document.createElement('div');
   metrics.className = 'metrics';
   metrics.innerHTML = `
-      <div class="metric">❤️ <span class="v pv"></span> /10</div>
+      <div class="metric">❤️ <span class="v pv"></span> /<span class="v maxPv"></span></div>
       <div class="metric">⭐ <span class="v pa"></span></div>
       <div class="metric">🥾 <span class="v pm"></span></div>
     `;
@@ -183,6 +184,7 @@ export function initUI() {
 
   bluePanelRefs = {
     pv: metrics.querySelector('.pv'),
+    maxPv: metrics.querySelector('.maxPv'),
     pa: metrics.querySelector('.pa'),
     pm: metrics.querySelector('.pm'),
   };

--- a/js/units.js
+++ b/js/units.js
@@ -7,6 +7,7 @@ let board = null;
 export const units = {
   blue: {
     id: 'blue',
+    maxPv: 10,
     pv: 10,
     pm: 3,
     pa: 6,
@@ -18,6 +19,7 @@ export const units = {
   },
   red: {
     id: 'red',
+    maxPv: 10,
     pv: 10,
     pm: 3,
     pa: 6,
@@ -51,11 +53,13 @@ export function initUnits(cardEls, isBlue, isRed) {
 
 export function resetUnits() {
   units.blue.pos = { row: 5, col: 3 };
-  units.blue.pv = 10;
+  units.blue.maxPv = 10;
+  units.blue.pv = units.blue.maxPv;
   units.blue.pm = 3;
   units.blue.pa = 6;
   units.red.pos = { row: 0, col: 0 };
-  units.red.pv = 10;
+  units.red.maxPv = 10;
+  units.red.pv = units.red.maxPv;
   units.red.pm = 3;
   units.red.pa = 6;
   Object.values(units).forEach(u => {

--- a/tests/items.test.js
+++ b/tests/items.test.js
@@ -91,4 +91,12 @@ describe('itemsConfig configuration', () => {
     expect(targets[3].pv).toBe(10);
     expect(bomb.consumable).toBe(true);
   });
+
+  test('shield increases maxPv without healing', () => {
+    const shield = itemsConfig.find(i => i.id === 'escudo');
+    const unit = { pv: 8, maxPv: 10 };
+    shield.apply(unit);
+    expect(unit.maxPv).toBe(13);
+    expect(unit.pv).toBe(8);
+  });
 });


### PR DESCRIPTION
## Summary
- track each unit's maxPv and reset it to 10 on restart
- update shield item to raise maxPv instantly and adjust UI to show current/max
- verify shield behavior with new test

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a39dd0dc20832e90709774144f726f