### PR TITLE
Allow shield item to be stored

### DIFF
--- a/js/config.js
+++ b/js/config.js
@@ -72,7 +72,7 @@ export const itemsConfig = [
     range: 0,
     effect: 'Aumenta PV máximo em 3',
     consumable: true,
-    usable: false,
+    usable: true,
     apply(unit) {
       unit.maxPv = (unit.maxPv ?? 10) + 3;
     },

--- a/tests/items.test.js
+++ b/tests/items.test.js
@@ -94,6 +94,7 @@ describe('itemsConfig configuration', () => {
 
   test('shield increases maxPv without healing', () => {
     const shield = itemsConfig.find(i => i.id === 'escudo');
+    expect(shield.usable).toBe(true);
     const unit = { pv: 8, maxPv: 10 };
     shield.apply(unit);
     expect(unit.maxPv).toBe(13);


### PR DESCRIPTION
## Summary
- Make the shield loot item storable by setting `usable` to true
- Adjust unit test to verify shield is usable

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a3e89d346c832eafb46bc67fa2426b