### PR TITLE
Fix cost deduction for heal item

### DIFF
--- a/js/config.js
+++ b/js/config.js
@@ -17,7 +17,6 @@ export const itemsConfig = [
     consumable: true,
     usable: true,
     apply(unit) {
-      unit.pa -= 1;
       unit.pv = Math.min(unit.pv + 2, unit.maxPv || 10);
     },
   },

--- a/tests/items.test.js
+++ b/tests/items.test.js
@@ -24,10 +24,10 @@ describe('itemsConfig configuration', () => {
     const base = { pv: 10, pa: 5, attack: 1 };
     const find = id => itemsConfig.find(i => i.id === id);
 
-    const heartTarget = { pv: 8, pa: 5 };
+    const heartTarget = { pv: 8, pa: 5, maxPv: 10 };
     find('vida+2').apply(heartTarget);
     expect(heartTarget.pv).toBe(10);
-    expect(heartTarget.pa).toBe(4);
+    expect(heartTarget.pa).toBe(5);
 
     const u4 = { ...base };
     find('bomba').apply(u4);

--- a/tests/ui.test.js
+++ b/tests/ui.test.js
@@ -2,6 +2,7 @@ import { jest } from '@jest/globals';
 const { passTurn, stopTurnTimer, startTurnTimer, initUI, addItemCard, uiState } = await import('../js/ui.js');
 const { units, setActiveId } = await import('../js/units.js');
 const { startBattle, gameOver } = await import('../js/main.js');
+const { itemsConfig } = await import('../js/config.js');
 
 describe('passTurn', () => {
   beforeEach(() => {
@@ -88,4 +89,24 @@ describe('startBattle', () => {
     jest.runOnlyPendingTimers();
     jest.useRealTimers();
   }, 10000);
+});
+
+describe('addItemCard', () => {
+  afterEach(() => {
+    document.body.innerHTML = '';
+  });
+
+  test('using heal item subtracts PA cost once', () => {
+    document.body.innerHTML = '<div class="page"></div>';
+    initUI();
+    units.blue.pa = 6;
+    units.blue.pv = 8;
+    const heart = itemsConfig.find(i => i.id === 'vida+2');
+    addItemCard(heart);
+    const card = document.querySelector('.card-item');
+    card.click();
+    expect(units.blue.pa).toBe(5);
+    expect(units.blue.pv).toBe(10);
+    expect(document.querySelector('.card-item')).toBeNull();
+  });
 });


### PR DESCRIPTION
## Summary
- Remove extra PA reduction from vida+2 item's apply function
- Adjust existing item tests and add UI test to ensure correct PA cost when using items

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a3eb410ee8832ea3c4c61fd78ff20d