### PR TITLE
feat: highlight movement without hover

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -51,6 +51,8 @@ export async function startBattle() {
   showPopup('Iniciando turno do jogador azul', {
     corner: 'top-left',
   });
+  // Mostra casas alcançáveis para o jogador inicial sem exigir hover
+  if (units.blue.allow) showReachableFor(units.blue);
 }
 
 export async function moveUnitAlongPath(unit, path, cost) {
@@ -271,6 +273,8 @@ document.addEventListener('DOMContentLoaded', () => {
       card.classList.remove('is-selected');
       ui.uiState.selectedItem = null;
       clearItemAlcance();
+      // Após usar o item, reexibe alcance de movimento caso haja PM
+      if (active.allow) showReachableFor(active);
       return;
     }
     if (ui.uiState.socoSelecionado && cell.classList.contains('attackable')) {
@@ -288,6 +292,8 @@ document.addEventListener('DOMContentLoaded', () => {
       ui.uiState.socoSelecionado = false;
       ui.uiState.socoSlot.classList.remove('is-selected');
       clearSocoAlcance();
+       // Após atacar, reexibe alcance de movimento caso haja PM
+      if (active.allow) showReachableFor(active);
       return;
     }
 

--- a/js/ui.js
+++ b/js/ui.js
@@ -3,6 +3,7 @@ import {
   getActive,
   setActiveId,
   clearReachable,
+  showReachableFor,
   showSocoAlcance as showSocoAlcanceUnits,
   clearSocoAlcance as clearSocoAlcanceUnits,
   showItemAlcance as showItemAlcanceUnits,
@@ -119,6 +120,9 @@ export function passTurn() {
   uiState.selectedItem = null;
   clearItemAlcance();
   updateBluePanel(units.blue);
+  // Destaca alcance de movimento da unidade ativa sem depender de hover
+  const activeUnit = getActive();
+  if (activeUnit.allow) showReachableFor(activeUnit);
   checkGameOver();
   if (units.blue.pv > 0 && units.red.pv > 0) {
     startTurnTimer();


### PR DESCRIPTION
## Summary
- highlight reachable tiles automatically when a turn begins
- restore movement highlighting after using items or melee attack

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a3ee5b6084832eaa7ca3de4f7e78ac