### PR TITLE
Add keyboard shortcuts for turn passing and slot selection

### DIFF
--- a/js/ui.js
+++ b/js/ui.js
@@ -52,6 +52,29 @@ let intervalId = null;
 let passBtn = null;
 let timerEl = null;
 
+let shortcutsBound = false;
+
+function handleShortcuts(ev) {
+  if (ev.code === 'Space') {
+    ev.preventDefault();
+    passTurn();
+    return;
+  }
+  const key = ev.key;
+  if (!['1', '2', '3', '4'].includes(key)) return;
+  if (getActive().id !== 'blue') return;
+  const slots = document.querySelectorAll('.turn-panel .slot');
+  const idx = Number(key) - 1;
+  const slot = slots[idx];
+  if (!slot) return;
+  if (idx === 0) {
+    slot.click();
+  } else {
+    const card = slot.firstElementChild;
+    card?.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+  }
+}
+
 function updatePassButton() {
   if (!passBtn || !timerEl) return;
   passBtn.textContent = 'Passar Vez';
@@ -195,6 +218,11 @@ export function initUI() {
   updateBluePanel(units.blue);
 
   passBtn.addEventListener('click', passTurn);
+
+  if (!shortcutsBound) {
+    document.addEventListener('keydown', handleShortcuts);
+    shortcutsBound = true;
+  }
 }
 
 export function addItemCard(item) {

--- a/tests/ui.test.js
+++ b/tests/ui.test.js
@@ -1,6 +1,6 @@
 import { jest } from '@jest/globals';
 const { passTurn, stopTurnTimer, startTurnTimer, initUI, addItemCard, uiState } = await import('../js/ui.js');
-const { units, setActiveId } = await import('../js/units.js');
+const { units, setActiveId, getActive } = await import('../js/units.js');
 const { startBattle, gameOver } = await import('../js/main.js');
 const { itemsConfig } = await import('../js/config.js');
 
@@ -108,5 +108,47 @@ describe('addItemCard', () => {
     expect(units.blue.pa).toBe(5);
     expect(units.blue.pv).toBe(10);
     expect(document.querySelector('.card-item')).toBeNull();
+  });
+});
+
+describe('keyboard shortcuts', () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+    document.body.innerHTML = '<div class="page"></div>';
+    initUI();
+  });
+
+  afterEach(() => {
+    stopTurnTimer();
+    jest.runOnlyPendingTimers();
+    jest.useRealTimers();
+    document.body.innerHTML = '';
+    uiState.socoSelecionado = false;
+    uiState.selectedItem = null;
+  });
+
+  test('spacebar passes the turn', () => {
+    setActiveId('blue');
+    const evt = new KeyboardEvent('keydown', { code: 'Space' });
+    document.dispatchEvent(evt);
+    expect(getActive().id).toBe('red');
+  });
+
+  test('number keys select corresponding slots for blue turn', () => {
+    setActiveId('blue');
+    const sword = itemsConfig.find(i => i.id === 'espada');
+    addItemCard(sword);
+    const hammer = itemsConfig.find(i => i.id === 'martelo');
+    addItemCard(hammer);
+    document.dispatchEvent(new KeyboardEvent('keydown', { key: '1' }));
+    expect(uiState.socoSelecionado).toBe(true);
+    document.dispatchEvent(new KeyboardEvent('keydown', { key: '3' }));
+    expect(uiState.selectedItem?.item).toBe(hammer);
+  });
+
+  test('number keys ignored when it is not blue turn', () => {
+    setActiveId('red');
+    document.dispatchEvent(new KeyboardEvent('keydown', { key: '1' }));
+    expect(uiState.socoSelecionado).toBe(false);
   });
 });


### PR DESCRIPTION
## Summary
- Add global keyboard shortcuts: Space to pass turn and keys 1-4 to select slots during blue's turn
- Wire shortcuts when UI initializes
- Test keyboard interactions for turn passing and slot selection

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a3f2de96e4832e9afbd7ffba8e97e4