### PR TITLE
Display item stats in inventory slots

### DIFF
--- a/css/turn-panel.css
+++ b/css/turn-panel.css
@@ -27,7 +27,8 @@
 }
 
 .slot .card-soco,
-.slot .card-extra {
+.slot .card-extra,
+.slot .card-item {
   display: flex;
   align-items: center;
   justify-content: center;
@@ -36,12 +37,22 @@
 }
 
 .slot .card-soco .atk,
-.slot .card-extra .atk {
+.slot .card-extra .atk,
+.slot .card-item .atk,
+.slot .card-item .hp {
   position: absolute;
   top: 2px;
   right: 4px;
   font-size: 14px;
   font-weight: 700;
+}
+
+.slot .card-item .atk {
+  color: #fff;
+}
+
+.slot .card-item .hp {
+  color: #ef4444;
 }
 
 .slot.is-selected {

--- a/js/config.js
+++ b/js/config.js
@@ -16,6 +16,7 @@ export const itemsConfig = [
     effect: 'Cura 2 PV',
     consumable: true,
     usable: true,
+    pvBonus: 2,
     apply(unit) {
       unit.pv = Math.min(unit.pv + 2, unit.maxPv || 10);
     },
@@ -72,6 +73,7 @@ export const itemsConfig = [
     effect: 'Aumenta PV máximo em 3',
     consumable: true,
     usable: true,
+    pvBonus: 3,
     apply(unit) {
       unit.maxPv = (unit.maxPv ?? 10) + 3;
     },

--- a/js/ui.js
+++ b/js/ui.js
@@ -253,6 +253,18 @@ export function addItemCard(item) {
   card.title = item.effect;
   card.dataset.itemId = item.id;
 
+  if (item.type === 'attack') {
+    const atk = document.createElement('span');
+    atk.className = 'atk';
+    atk.textContent = String(item.damage);
+    card.appendChild(atk);
+  } else if (item.pvBonus) {
+    const hp = document.createElement('span');
+    hp.className = 'hp';
+    hp.textContent = `+${item.pvBonus}`;
+    card.appendChild(hp);
+  }
+
   card.addEventListener('click', () => {
     if (getActive().id !== 'blue') return;
     if (item.type === 'attack') {

--- a/tests/gameOver.test.js
+++ b/tests/gameOver.test.js
@@ -84,7 +84,7 @@ describe('gameOver victory chest', () => {
 
     const slots = document.querySelectorAll('.slot');
     const card = slots[1].firstElementChild;
-    expect(card?.textContent).toBe('🗡️');
+    expect(card?.textContent).toBe('🗡️3');
     expect(units.blue.attack).toBeUndefined();
 
     // Clicking the card toggles selection but does not change stats
@@ -108,7 +108,7 @@ describe('gameOver victory chest', () => {
 
     const slots = document.querySelectorAll('.slot');
     const card = slots[1].firstElementChild;
-    expect(card?.textContent).toBe('💖');
+    expect(card?.textContent).toBe('💖+2');
 
     units.blue.pv = 8;
     card?.dispatchEvent(new Event('click'));

--- a/tests/ui.test.js
+++ b/tests/ui.test.js
@@ -120,6 +120,28 @@ describe('addItemCard', () => {
     expect(units.blue.pv).toBe(10);
     expect(document.querySelector('.card-item')).toBeNull();
   });
+
+  test('attack items display their damage value', () => {
+    document.body.innerHTML = '<div class="page"></div>';
+    initUI();
+    const hammer = itemsConfig.find(i => i.id === 'martelo');
+    addItemCard(hammer);
+    const card = document.querySelector('.card-item');
+    const atk = card.querySelector('.atk');
+    expect(atk).not.toBeNull();
+    expect(atk.textContent).toBe(String(hammer.damage));
+  });
+
+  test('defensive items display life bonus in red', () => {
+    document.body.innerHTML = '<div class="page"></div>';
+    initUI();
+    const shield = itemsConfig.find(i => i.id === 'escudo');
+    addItemCard(shield);
+    const card = document.querySelector('.card-item');
+    const hp = card.querySelector('.hp');
+    expect(hp).not.toBeNull();
+    expect(hp.textContent).toBe(`+${shield.pvBonus}`);
+  });
 });
 
 describe('inventory management', () => {


### PR DESCRIPTION
## Summary
- Ensure inventory item cards render at full size and include damage or life indicators
- Store life bonuses in item config for heart and shield and display them with red styling
- Test that attack and defensive items show their values in slots

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a3fd474fd0832e88c155c011ef161e