### PR TITLE
feat: make shield passive

### DIFF
--- a/js/config.js
+++ b/js/config.js
@@ -71,11 +71,13 @@ export const itemsConfig = [
     damage: 0,
     range: 0,
     effect: 'Aumenta PV máximo em 3',
-    consumable: true,
+    consumable: false,
     usable: true,
     pvBonus: 3,
     apply(unit) {
-      unit.maxPv = (unit.maxPv ?? 10) + 3;
+      const bonus = this.pvBonus || 0;
+      unit.maxPv = (unit.maxPv ?? 10) + bonus;
+      unit.pv = Math.min((unit.pv ?? 0) + bonus, unit.maxPv);
     },
   },
 ];

--- a/tests/gameOver.test.js
+++ b/tests/gameOver.test.js
@@ -116,7 +116,7 @@ describe('gameOver victory chest', () => {
     expect(slots[1].children.length).toBe(0);
   });
 
-  test('shield increases maxPv only when card is used', () => {
+  test('shield increases PV and maxPv passively without being consumed', () => {
     jest.spyOn(Math, 'random').mockReturnValue(0.8);
     units.blue.maxPv = 10;
     units.blue.pv = 10;
@@ -128,11 +128,13 @@ describe('gameOver victory chest', () => {
 
     const slots = document.querySelectorAll('.slot');
     expect(slots[1].children.length).toBe(1);
-    expect(units.blue.maxPv).toBe(10);
+    expect(units.blue.maxPv).toBe(13);
+    expect(units.blue.pv).toBe(13);
 
     const card = slots[1].firstElementChild;
     card?.dispatchEvent(new Event('click'));
     expect(units.blue.maxPv).toBe(13);
-    expect(slots[1].children.length).toBe(0);
+    expect(units.blue.pv).toBe(13);
+    expect(slots[1].children.length).toBe(1);
   });
 });

--- a/tests/items.test.js
+++ b/tests/items.test.js
@@ -92,12 +92,13 @@ describe('itemsConfig configuration', () => {
     expect(bomb.consumable).toBe(true);
   });
 
-  test('shield increases maxPv without healing', () => {
+  test('shield increases current and max Pv without being consumable', () => {
     const shield = itemsConfig.find(i => i.id === 'escudo');
     expect(shield.usable).toBe(true);
     const unit = { pv: 8, maxPv: 10 };
     shield.apply(unit);
     expect(unit.maxPv).toBe(13);
-    expect(unit.pv).toBe(8);
+    expect(unit.pv).toBe(11);
+    expect(shield.consumable).toBe(false);
   });
 });

--- a/tests/ui.test.js
+++ b/tests/ui.test.js
@@ -105,6 +105,10 @@ describe('startBattle', () => {
 describe('addItemCard', () => {
   afterEach(() => {
     document.body.innerHTML = '';
+    units.blue.maxPv = 10;
+    units.blue.pv = 10;
+    units.blue.pa = 6;
+    units.blue.pm = 3;
   });
 
   test('using heal item subtracts PA cost once', () => {
@@ -141,6 +145,22 @@ describe('addItemCard', () => {
     const hp = card.querySelector('.hp');
     expect(hp).not.toBeNull();
     expect(hp.textContent).toBe(`+${shield.pvBonus}`);
+  });
+
+  test('shield item passively increases PV and max PV without being consumed', () => {
+    document.body.innerHTML = '<div class="page"></div>';
+    initUI();
+    units.blue.pv = 10;
+    units.blue.maxPv = 10;
+    const shield = itemsConfig.find(i => i.id === 'escudo');
+    addItemCard(shield);
+    expect(units.blue.maxPv).toBe(10 + shield.pvBonus);
+    expect(units.blue.pv).toBe(10 + shield.pvBonus);
+    const card = document.querySelector('.card-item');
+    card.click();
+    expect(units.blue.maxPv).toBe(10 + shield.pvBonus);
+    expect(units.blue.pv).toBe(10 + shield.pvBonus);
+    expect(document.querySelector('.card-item')).not.toBeNull();
   });
 });
 


### PR DESCRIPTION
## Summary
- shield no longer consumable; applying it boosts max PV and heals by its bonus
- recalculate PV bonus from non-consumable items whenever inventory updates or loads
- update tests for passive shield behaviour

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a402e53c48832e8b29b3664abc715f