### PR TITLE
Toggle selection on inventory slots

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -235,7 +235,7 @@ document.addEventListener('DOMContentLoaded', () => {
     const selected = ui.uiState.selectedItem;
     if (selected && cell.classList.contains('attackable')) {
       const enemy = getInactive();
-      const { item, card } = selected;
+      const { item, card, slot } = selected;
       if (item.pattern === 'T') {
         const cells = getTPatternCells(active, enemy);
         const hit = cells.some(
@@ -280,7 +280,7 @@ document.addEventListener('DOMContentLoaded', () => {
         checkGameOver();
       }
       if (item.consumable) card.remove();
-      card.classList.remove('is-selected');
+      slot.classList.remove('is-selected');
       ui.uiState.selectedItem = null;
       clearItemAlcance();
       // Após usar o item, reexibe alcance de movimento caso haja PM

--- a/tests/gameOver.test.js
+++ b/tests/gameOver.test.js
@@ -83,17 +83,18 @@ describe('gameOver victory chest', () => {
     lootItem?.dispatchEvent(new Event('click'));
 
     const slots = document.querySelectorAll('.slot');
-    const card = slots[1].firstElementChild;
+    const slot = slots[1];
+    const card = slot.firstElementChild;
     expect(card?.textContent).toBe('🗡️3');
     expect(units.blue.attack).toBeUndefined();
 
-    // Clicking the card toggles selection but does not change stats
-    card?.dispatchEvent(new Event('click'));
+    // Clicking the slot toggles selection but does not change stats
+    slot.dispatchEvent(new Event('click'));
     expect(units.blue.attack).toBeUndefined();
     expect(ui.uiState.selectedItem?.item.id).toBe('espada');
 
     // Deselecting keeps the card for later use
-    card?.dispatchEvent(new Event('click'));
+    slot.dispatchEvent(new Event('click'));
     expect(ui.uiState.selectedItem).toBeNull();
     expect(slots[1].children.length).toBe(1);
   });
@@ -107,11 +108,12 @@ describe('gameOver victory chest', () => {
     lootItem?.dispatchEvent(new Event('click'));
 
     const slots = document.querySelectorAll('.slot');
-    const card = slots[1].firstElementChild;
+    const slot = slots[1];
+    const card = slot.firstElementChild;
     expect(card?.textContent).toBe('💖+2');
 
     units.blue.pv = 8;
-    card?.dispatchEvent(new Event('click'));
+    slot.dispatchEvent(new Event('click'));
     expect(units.blue.pv).toBe(10);
     expect(slots[1].children.length).toBe(0);
   });

--- a/tests/ui.test.js
+++ b/tests/ui.test.js
@@ -147,6 +147,16 @@ describe('addItemCard', () => {
     expect(hp.textContent).toBe(`+${shield.pvBonus}`);
   });
 
+  test('selecting an attack item highlights its slot', () => {
+    document.body.innerHTML = '<div class="page"></div>';
+    initUI();
+    const sword = itemsConfig.find(i => i.id === 'espada');
+    addItemCard(sword);
+    const slot = document.querySelector('.turn-panel .slot:nth-child(2)');
+    slot?.dispatchEvent(new Event('click'));
+    expect(slot?.classList.contains('is-selected')).toBe(true);
+  });
+
   test('shield item passively increases PV and max PV without being consumed', () => {
     document.body.innerHTML = '<div class="page"></div>';
     initUI();
@@ -230,10 +240,14 @@ describe('keyboard shortcuts', () => {
     addItemCard(sword);
     const hammer = itemsConfig.find(i => i.id === 'martelo');
     addItemCard(hammer);
+    const slots = document.querySelectorAll('.turn-panel .slot');
     document.dispatchEvent(new KeyboardEvent('keydown', { key: '1' }));
-    expect(uiState.socoSelecionado).toBe(true);
+    expect(slots[0].classList.contains('is-selected')).toBe(true);
     document.dispatchEvent(new KeyboardEvent('keydown', { key: '3' }));
+    expect(slots[0].classList.contains('is-selected')).toBe(false);
+    expect(slots[2].classList.contains('is-selected')).toBe(true);
     expect(uiState.selectedItem?.item).toBe(hammer);
+    expect(uiState.selectedItem?.slot).toBe(slots[2]);
   });
 
   test('number keys ignored when it is not blue turn', () => {


### PR DESCRIPTION
## Summary
- Toggle inventory selection on slot elements and track them in `uiState`
- Ensure keyboard shortcuts trigger slot clicks
- Update tests for slot-based selection

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a405d5a6c0832eb1e790902c1178b9