### PR TITLE
Clear slot selections on turn pass

### DIFF
--- a/js/ui.js
+++ b/js/ui.js
@@ -153,12 +153,15 @@ export function passTurn() {
     duration: 1000,
   });
   clearReachable();
-  uiState.selectedItem?.slot?.classList.remove('is-selected');
+  const selectedSlots = document.querySelectorAll('.turn-panel .slot.is-selected');
+  const socoWasSelected = uiState.socoSlot?.classList.contains('is-selected');
+  selectedSlots.forEach(slot => slot.classList.remove('is-selected'));
   uiState.selectedItem = null;
   clearItemAlcance();
   uiState.socoSelecionado = false;
-  uiState.socoSlot?.classList.remove('is-selected');
-  clearSocoAlcance();
+  if (socoWasSelected) {
+    clearSocoAlcance();
+  }
   updateBluePanel(units.blue);
   // Destaca alcance de movimento da unidade ativa sem depender de hover
   const activeUnit = getActive();

--- a/tests/ui.test.js
+++ b/tests/ui.test.js
@@ -51,6 +51,23 @@ describe('passTurn', () => {
     jest.advanceTimersByTime(300);
     expect(document.querySelector('.popup')).toBeNull();
   });
+
+  test('passing the turn clears all slot selections', () => {
+    document.body.innerHTML = '<div class="page"></div>';
+    initUI();
+    const sword = itemsConfig.find(i => i.id === 'espada');
+    addItemCard(sword);
+    setActiveId('blue');
+    uiState.socoSlot.classList.add('is-selected');
+    uiState.socoSelecionado = true;
+    const secondSlot = document.querySelector('.turn-panel .slot:nth-child(2)');
+    secondSlot.classList.add('is-selected');
+    uiState.selectedItem = { item: sword, slot: secondSlot };
+    passTurn();
+    expect(document.querySelectorAll('.turn-panel .slot.is-selected').length).toBe(0);
+    expect(uiState.socoSelecionado).toBe(false);
+    expect(uiState.selectedItem).toBeNull();
+  });
 });
 
 describe('startBattle', () => {


### PR DESCRIPTION
## Summary
- ensure passing the turn removes `is-selected` from all slots and resets punch selection
- clear punch range when deselecting the punch slot
- test that passing the turn clears all slot selections

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a407a68704832eaad68b0065df0533