### PR TITLE
Add start screen with new or continue options

### DIFF
--- a/index.html
+++ b/index.html
@@ -12,7 +12,12 @@
       <link rel="stylesheet" href="./css/overlay.css" />
   </head>
   <body>
-    <div id="map-screen">
+    <div id="start-screen">
+      <button id="new-game" class="pass-btn">Novo</button>
+      <button id="continue-game" class="pass-btn">Continuar</button>
+    </div>
+
+    <div id="map-screen" style="display:none">
       <div class="map-container" id="map">
         <button id="play" class="pass-btn map-play-btn">Desafiar</button>
       </div>

--- a/js/map.js
+++ b/js/map.js
@@ -13,6 +13,9 @@ const container = document.getElementById('map');
 const mapScreen = document.getElementById('map-screen');
 const boardScreen = document.getElementById('board-screen');
 const playBtn = document.getElementById('play');
+const startScreen = document.getElementById('start-screen');
+const newBtn = document.getElementById('new-game');
+const continueBtn = document.getElementById('continue-game');
 
 function getStage() {
   let stage = Number(localStorage.getItem(stageKey));
@@ -78,5 +81,18 @@ playBtn?.addEventListener('click', () => {
   if (boardScreen) boardScreen.style.display = '';
   showOverlay();
   startBattle();
+});
+
+newBtn?.addEventListener('click', () => {
+  localStorage.clear();
+  renderMap();
+  if (startScreen) startScreen.style.display = 'none';
+  if (mapScreen) mapScreen.style.display = '';
+});
+
+continueBtn?.addEventListener('click', () => {
+  renderMap();
+  if (startScreen) startScreen.style.display = 'none';
+  if (mapScreen) mapScreen.style.display = '';
 });
 

--- a/tests/startScreen.test.js
+++ b/tests/startScreen.test.js
@@ -1,0 +1,43 @@
+import { jest } from '@jest/globals';
+
+describe('start screen', () => {
+  beforeEach(() => {
+    jest.resetModules();
+    localStorage.clear();
+    document.body.innerHTML = `
+      <div id="start-screen">
+        <button id="new-game"></button>
+        <button id="continue-game"></button>
+      </div>
+      <div id="map-screen" style="display:none">
+        <div class="map-container" id="map"></div>
+        <button id="play"></button>
+      </div>
+      <div id="board-screen"></div>
+    `;
+  });
+
+  afterEach(() => {
+    document.body.innerHTML = '';
+  });
+
+  test('starts a new game clearing storage', async () => {
+    localStorage.setItem('stage', '2');
+    localStorage.setItem('foo', 'bar');
+    await import('../js/map.js');
+    document.getElementById('new-game').click();
+    expect(localStorage.getItem('foo')).toBeNull();
+    expect(localStorage.getItem('stage')).toBe('0');
+    expect(document.getElementById('start-screen').style.display).toBe('none');
+    expect(document.getElementById('map-screen').style.display).toBe('');
+  });
+
+  test('continues existing game without clearing storage', async () => {
+    localStorage.setItem('stage', '1');
+    await import('../js/map.js');
+    document.getElementById('continue-game').click();
+    expect(localStorage.getItem('stage')).toBe('1');
+    expect(document.getElementById('start-screen').style.display).toBe('none');
+    expect(document.getElementById('map-screen').style.display).toBe('');
+  });
+});


### PR DESCRIPTION
## Summary
- Add initial start screen offering **Novo** and **Continuar** options
- Clear progress when starting a new game and re-render map
- Add tests covering start screen interactions

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a47a308c58832eb0e7ee4a1f5082cb