### PR TITLE
refactor: load map script via main module only

### DIFF
--- a/index.html
+++ b/index.html
@@ -69,6 +69,5 @@
       </div>
     </div>
     <script type="module" src="js/main.js"></script>
-    <script type="module" src="js/map.js"></script>
   </body>
 </html>


### PR DESCRIPTION
## Summary
- remove redundant map.js script tag from index.html so module is loaded via main.js

## Testing
- `npm test`
- manual jsdom checks: start screen renders once and buttons hide start screen as expected

------
https://chatgpt.com/codex/tasks/task_e_68a483f69c54832eaf82c9ea9bf62664