### PR TITLE
refactor: isolate map and battle start into game module

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,8 @@ Protótipo de jogo de tabuleiro com cartas e turnos, escrito em HTML, CSS e Java
 ## Estrutura
 
 - `map.html`: mapa de fases com indicação do estágio atual.
-- `js/map.js`: renderização do mapa e controle do estágio.
+- `js/game.js`: lógica de mapa e inicialização de batalha.
+- `js/map.js`: configuração da tela do mapa.
 - `index.html`: marcação principal do tabuleiro.
 - Diretório `css/`: estilos da interface.
 - `js/main.js`: lógica de jogo e controle de turnos.

--- a/js/game.js
+++ b/js/game.js
@@ -1,0 +1,106 @@
+const path = [
+  { x: 80, y: 420 },
+  { x: 80, y: 320 },
+  { x: 80, y: 220 },
+  { x: 80, y: 120 },
+  { x: 80, y: 20 },
+];
+
+const stageKey = 'stage';
+const playedKey = 'played';
+
+function getStage() {
+  let stage = Number(localStorage.getItem(stageKey));
+  if (Number.isNaN(stage)) stage = 0;
+  if (localStorage.getItem(playedKey)) {
+    stage = Number(localStorage.getItem(stageKey)) || stage;
+    localStorage.removeItem(playedKey);
+  }
+  localStorage.setItem(stageKey, String(stage));
+  return stage;
+}
+
+export function renderMap() {
+  const container = document.getElementById('map');
+  const playBtn = document.getElementById('play');
+  if (!container || !playBtn) return;
+
+  const stage = getStage();
+
+  container
+    .querySelectorAll('.map-node, .map-connection')
+    .forEach(el => el.remove());
+
+  path.forEach((node, idx) => {
+    const el = document.createElement('div');
+    el.className = 'map-node';
+    if (idx === stage) el.classList.add('current');
+    else if (idx < stage) el.classList.add('past');
+    el.style.left = `${node.x}px`;
+    el.style.top = `${node.y}px`;
+    container.appendChild(el);
+
+    if (idx > 0) {
+      const prev = path[idx - 1];
+      const conn = document.createElement('div');
+      conn.className = 'map-connection';
+      conn.style.left = `${prev.x + 10}px`;
+      conn.style.top = `${Math.min(prev.y, node.y) + 12}px`;
+      conn.style.height = `${Math.abs(node.y - prev.y)}px`;
+      container.appendChild(conn);
+    }
+  });
+
+  const current = path[stage];
+  if (current) {
+    playBtn.style.left = `${current.x + 12}px`;
+    playBtn.style.top = `${current.y + 40}px`;
+    playBtn.style.transform = 'translate(-50%, 0)';
+    playBtn.disabled = false;
+    playBtn.style.display = '';
+  } else {
+    playBtn.disabled = true;
+    playBtn.style.display = 'none';
+  }
+}
+
+import {
+  units,
+  mountUnit,
+  showReachableFor,
+  resetUnits,
+} from './units.js';
+import {
+  resetUI,
+  loadInventory,
+  startTurnTimer,
+} from './ui.js';
+import { showOverlay, showPopup } from './overlay.js';
+
+export async function startBattle() {
+  document.querySelectorAll('.chest, .loot').forEach(el => el.remove());
+  resetUnits();
+  resetUI();
+  loadInventory();
+  // Recalcula a posição das unidades após o tabuleiro ficar visível. Caso os
+  // elementos sejam montados enquanto o tabuleiro está oculto (`display: none`),
+  // `getBoundingClientRect` retorna dimensões zero e as unidades desaparecem.
+  // Montá-las novamente garante que largura, altura e posição sejam atualizadas
+  // corretamente quando a batalha inicia.
+  mountUnit(units.blue);
+  mountUnit(units.red);
+
+  const overlay = showOverlay('Desafio contra vermelho', { persist: true });
+  for (let i = 3; i > 0; i--) {
+    overlay.textContent = String(i);
+    await new Promise(r => setTimeout(r, 1000));
+  }
+  overlay.classList.add('fade-out');
+  setTimeout(() => overlay.remove(), 300);
+  startTurnTimer();
+  showPopup('Iniciando turno do jogador azul', {
+    corner: 'top-left',
+  });
+  // Mostra casas alcançáveis para o jogador inicial sem exigir hover
+  if (units.blue.allow) showReachableFor(units.blue);
+}

--- a/js/main.js
+++ b/js/main.js
@@ -11,7 +11,6 @@ import {
   clearItemAlcance,
   showFloatingText,
   getCoords,
-  resetUnits,
   getTPatternCells,
   getCrossPatternCells,
   clearPathHighlight,
@@ -23,46 +22,15 @@ const {
   initUI,
   updateBluePanel,
   initEnemyTooltip,
-  startTurnTimer,
-  resetUI,
-  loadInventory,
 } = ui;
 import { getRandomItems } from './config.js';
-import { showOverlay, showPopup } from './overlay.js';
-import { renderMap } from './map.js';
+import { showOverlay } from './overlay.js';
 
 export function checkGameOver() {
   if (units.blue.pv <= 0) ui.gameOver('derrota');
   else if (units.red.pv <= 0) gameOver('vitoria');
 }
 
-export async function startBattle() {
-  document.querySelectorAll('.chest, .loot').forEach(el => el.remove());
-  resetUnits();
-  resetUI();
-  loadInventory();
-  // Recalcula a posição das unidades após o tabuleiro ficar visível. Caso os
-  // elementos sejam montados enquanto o tabuleiro está oculto (`display: none`),
-  // `getBoundingClientRect` retorna dimensões zero e as unidades desaparecem.
-  // Montá-las novamente garante que largura, altura e posição sejam atualizadas
-  // corretamente quando a batalha inicia.
-  mountUnit(units.blue);
-  mountUnit(units.red);
-
-  const overlay = showOverlay('Desafio contra vermelho', { persist: true });
-  for (let i = 3; i > 0; i--) {
-    overlay.textContent = String(i);
-    await new Promise(r => setTimeout(r, 1000));
-  }
-  overlay.classList.add('fade-out');
-  setTimeout(() => overlay.remove(), 300);
-  startTurnTimer();
-  showPopup('Iniciando turno do jogador azul', {
-    corner: 'top-left',
-  });
-  // Mostra casas alcançáveis para o jogador inicial sem exigir hover
-  if (units.blue.allow) showReachableFor(units.blue);
-}
 
 export async function moveUnitAlongPath(unit, path, cost) {
   if (path.length < 2) {
@@ -162,7 +130,7 @@ export function gameOver(result) {
                 const mapScreen = document.getElementById('map-screen');
                 if (boardScreen) boardScreen.style.display = 'none';
                 if (mapScreen) mapScreen.style.display = '';
-                renderMap();
+                import('./game.js').then(m => m.renderMap());
               });
             },
             { once: true },
@@ -327,5 +295,3 @@ document.addEventListener('DOMContentLoaded', () => {
 
   console.log('[Tabuleiro] Unidades inicializadas', units);
 });
-
-export { showOverlay };

--- a/js/map.js
+++ b/js/map.js
@@ -1,15 +1,6 @@
-const path = [
-  { x: 80, y: 420 },
-  { x: 80, y: 320 },
-  { x: 80, y: 220 },
-  { x: 80, y: 120 },
-  { x: 80, y: 20 },
-];
+import { renderMap, startBattle } from './game.js';
+import { showOverlay } from './overlay.js';
 
-const stageKey = 'stage';
-const playedKey = 'played';
-
-const container = document.getElementById('map');
 const mapScreen = document.getElementById('map-screen');
 const boardScreen = document.getElementById('board-screen');
 const playBtn = document.getElementById('play');
@@ -17,66 +8,11 @@ const startScreen = document.getElementById('start-screen');
 const newBtn = document.getElementById('new-game');
 const continueBtn = document.getElementById('continue-game');
 
-function getStage() {
-  let stage = Number(localStorage.getItem(stageKey));
-  if (Number.isNaN(stage)) stage = 0;
-  if (localStorage.getItem(playedKey)) {
-    stage = Number(localStorage.getItem(stageKey)) || stage;
-    localStorage.removeItem(playedKey);
-  }
-  localStorage.setItem(stageKey, String(stage));
-  return stage;
-}
-
-export function renderMap() {
-  if (!container || !playBtn) return;
-
-  const stage = getStage();
-
-  container
-    .querySelectorAll('.map-node, .map-connection')
-    .forEach(el => el.remove());
-
-  path.forEach((node, idx) => {
-    const el = document.createElement('div');
-    el.className = 'map-node';
-    if (idx === stage) el.classList.add('current');
-    else if (idx < stage) el.classList.add('past');
-    el.style.left = `${node.x}px`;
-    el.style.top = `${node.y}px`;
-    container.appendChild(el);
-
-    if (idx > 0) {
-      const prev = path[idx - 1];
-      const conn = document.createElement('div');
-      conn.className = 'map-connection';
-      conn.style.left = `${prev.x + 10}px`;
-      conn.style.top = `${Math.min(prev.y, node.y) + 12}px`;
-      conn.style.height = `${Math.abs(node.y - prev.y)}px`;
-      container.appendChild(conn);
-    }
-  });
-
-  const current = path[stage];
-  if (current) {
-    playBtn.style.left = `${current.x + 12}px`;
-    playBtn.style.top = `${current.y + 40}px`;
-    playBtn.style.transform = 'translate(-50%, 0)';
-    playBtn.disabled = false;
-    playBtn.style.display = '';
-  } else {
-    playBtn.disabled = true;
-    playBtn.style.display = 'none';
-  }
-}
-
-import { showOverlay, startBattle } from './main.js';
-
 renderMap();
 
 playBtn?.addEventListener('click', () => {
-  const stage = Number(localStorage.getItem(stageKey)) || 0;
-  localStorage.setItem(stageKey, String(stage));
+  const stage = Number(localStorage.getItem('stage')) || 0;
+  localStorage.setItem('stage', String(stage));
   if (mapScreen) mapScreen.style.display = 'none';
   if (boardScreen) boardScreen.style.display = '';
   showOverlay();
@@ -95,4 +31,3 @@ continueBtn?.addEventListener('click', () => {
   if (startScreen) startScreen.style.display = 'none';
   if (mapScreen) mapScreen.style.display = '';
 });
-

--- a/tests/main.test.js
+++ b/tests/main.test.js
@@ -3,7 +3,8 @@ import { jest } from '@jest/globals';
 const ui = await import('../js/ui.js');
 const { passTurn, stopTurnTimer } = ui;
 const { units, setActiveId } = await import('../js/units.js');
-const { checkGameOver, gameOver, startBattle } = await import('../js/main.js');
+const { checkGameOver, gameOver } = await import('../js/main.js');
+const { startBattle } = await import('../js/game.js');
 
 describe('game over logic', () => {
   beforeEach(() => {

--- a/tests/ui.test.js
+++ b/tests/ui.test.js
@@ -10,7 +10,8 @@ const {
   loadInventory,
 } = await import('../js/ui.js');
 const { units, setActiveId, getActive } = await import('../js/units.js');
-const { startBattle, gameOver } = await import('../js/main.js');
+const { gameOver } = await import('../js/main.js');
+const { startBattle } = await import('../js/game.js');
 const { itemsConfig } = await import('../js/config.js');
 
 describe('passTurn', () => {


### PR DESCRIPTION
## Summary
- move map rendering and battle initialization to new `game` module
- decouple `main.js` from map logic and rewire `map.js` to use `game.js`
- update tests for new module structure

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a485753fc4832ea58dccc16d78e2f1