### PR TITLE
Initialize start screen and add tests

### DIFF
--- a/js/map.js
+++ b/js/map.js
@@ -8,6 +8,13 @@ const startScreen = document.getElementById('start-screen');
 const newBtn = document.getElementById('new-game');
 const continueBtn = document.getElementById('continue-game');
 
+function initStartScreen() {
+  if (startScreen) startScreen.style.display = '';
+  if (mapScreen) mapScreen.style.display = 'none';
+  if (boardScreen) boardScreen.style.display = 'none';
+}
+
+initStartScreen();
 renderMap();
 
 playBtn?.addEventListener('click', () => {

--- a/tests/startScreen.test.js
+++ b/tests/startScreen.test.js
@@ -21,6 +21,13 @@ describe('start screen', () => {
     document.body.innerHTML = '';
   });
 
+  test('shows start screen initially', async () => {
+    await import('../js/map.js');
+    expect(document.getElementById('start-screen').style.display).toBe('');
+    expect(document.getElementById('map-screen').style.display).toBe('none');
+    expect(document.getElementById('board-screen').style.display).toBe('none');
+  });
+
   test('starts a new game clearing storage', async () => {
     localStorage.setItem('stage', '2');
     localStorage.setItem('foo', 'bar');


### PR DESCRIPTION
## Summary
- ensure start screen shows initially while hiding map and board
- test start screen visibility on initial load

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a487e48f6c832e97f48d58919e21f9