### PR TITLE
Adiciona teste da tela inicial

### DIFF
--- a/tests/startScreen.test.js
+++ b/tests/startScreen.test.js
@@ -21,7 +21,7 @@ describe('start screen', () => {
     document.body.innerHTML = '';
   });
 
-  test('shows start screen initially', async () => {
+  test('exibe tela inicial ao carregar', async () => {
     await import('../js/map.js');
     expect(document.getElementById('start-screen').style.display).toBe('');
     expect(document.getElementById('map-screen').style.display).toBe('none');


### PR DESCRIPTION
## Summary
- renomeia caso de teste para verificar que a tela inicial aparece ao carregar e as demais telas permanecem ocultas

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a489ed256c832e9a0fa55f522fd54b