### PR TITLE
Fix start screen buttons

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -25,6 +25,7 @@ const {
 } = ui;
 import { getRandomItems } from './config.js';
 import { showOverlay } from './overlay.js';
+import './map.js';
 
 export function checkGameOver() {
   if (units.blue.pv <= 0) ui.gameOver('derrota');

--- a/tests/map.test.js
+++ b/tests/map.test.js
@@ -17,7 +17,7 @@ describe('map progression', () => {
   test('advances to next node after victory', async () => {
     localStorage.setItem('stage', '1');
     localStorage.setItem('played', 'true');
-    await import('../js/map.js');
+    await import('../js/main.js');
     const nodes = document.querySelectorAll('.map-node');
     const currentIndex = Array.from(nodes).findIndex(n =>
       n.classList.contains('current'),

--- a/tests/moveUnitAlongPath.test.js
+++ b/tests/moveUnitAlongPath.test.js
@@ -25,6 +25,8 @@ jest.unstable_mockModule('../js/ui.js', () => ({
   updateBluePanel: jest.fn(),
   initEnemyTooltip: jest.fn(),
   startTurnTimer: jest.fn(),
+  resetUI: jest.fn(),
+  loadInventory: jest.fn(),
 }));
 
 jest.unstable_mockModule('../js/overlay.js', () => ({

--- a/tests/startScreen.test.js
+++ b/tests/startScreen.test.js
@@ -22,7 +22,7 @@ describe('start screen', () => {
   });
 
   test('exibe tela inicial ao carregar', async () => {
-    await import('../js/map.js');
+    await import('../js/main.js');
     expect(document.getElementById('start-screen').style.display).toBe('');
     expect(document.getElementById('map-screen').style.display).toBe('none');
     expect(document.getElementById('board-screen').style.display).toBe('none');
@@ -31,7 +31,7 @@ describe('start screen', () => {
   test('starts a new game clearing storage', async () => {
     localStorage.setItem('stage', '2');
     localStorage.setItem('foo', 'bar');
-    await import('../js/map.js');
+    await import('../js/main.js');
     document.getElementById('new-game').click();
     expect(localStorage.getItem('foo')).toBeNull();
     expect(localStorage.getItem('stage')).toBe('0');
@@ -41,7 +41,7 @@ describe('start screen', () => {
 
   test('continues existing game without clearing storage', async () => {
     localStorage.setItem('stage', '1');
-    await import('../js/map.js');
+    await import('../js/main.js');
     document.getElementById('continue-game').click();
     expect(localStorage.getItem('stage')).toBe('1');
     expect(document.getElementById('start-screen').style.display).toBe('none');


### PR DESCRIPTION
## Summary
- load map logic when the main module runs so "Novo" and "Continuar" buttons work
- adjust tests to verify start screen and map progression through the main entry point
- extend UI mocks for updated module dependencies

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a4e3d1dec8832e8929f0cab7a98caa