### PR TITLE
Centralize start buttons and disable resume without data

### DIFF
--- a/css/layout.css
+++ b/css/layout.css
@@ -6,6 +6,14 @@
   padding: 24px;
 }
 
+#start-screen {
+  min-height: 100vh;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  gap: 16px;
+}
+
 .layout {
   position: relative;
   width: min(840px, 90vw);

--- a/css/turn-panel.css
+++ b/css/turn-panel.css
@@ -89,6 +89,11 @@
 
 .pass-btn:hover { filter: brightness(1.05); }
 
+.pass-btn:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
 .turn-panel .turn-timer {
   font-weight: 700;
   opacity: .9;

--- a/js/map.js
+++ b/js/map.js
@@ -8,10 +8,15 @@ const startScreen = document.getElementById('start-screen');
 const newBtn = document.getElementById('new-game');
 const continueBtn = document.getElementById('continue-game');
 
+function updateContinueButton() {
+  if (continueBtn) continueBtn.disabled = !localStorage.getItem('stage');
+}
+
 function initStartScreen() {
   if (startScreen) startScreen.style.display = '';
   if (mapScreen) mapScreen.style.display = 'none';
   if (boardScreen) boardScreen.style.display = 'none';
+  updateContinueButton();
 }
 
 initStartScreen();

--- a/tests/startScreen.test.js
+++ b/tests/startScreen.test.js
@@ -26,6 +26,7 @@ describe('start screen', () => {
     expect(document.getElementById('start-screen').style.display).toBe('');
     expect(document.getElementById('map-screen').style.display).toBe('none');
     expect(document.getElementById('board-screen').style.display).toBe('none');
+    expect(document.getElementById('continue-game').disabled).toBe(true);
   });
 
   test('starts a new game clearing storage', async () => {
@@ -42,6 +43,7 @@ describe('start screen', () => {
   test('continues existing game without clearing storage', async () => {
     localStorage.setItem('stage', '1');
     await import('../js/main.js');
+    expect(document.getElementById('continue-game').disabled).toBe(false);
     document.getElementById('continue-game').click();
     expect(localStorage.getItem('stage')).toBe('1');
     expect(document.getElementById('start-screen').style.display).toBe('none');


### PR DESCRIPTION
## Summary
- Center "Novo" and "Continuar" buttons on the start screen
- Disable "Continuar" button when no saved progress
- Add visual styling for disabled buttons and corresponding tests

## Testing
- `CI=1 npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a4ee44464c832e941ff00e23a617ce