### PR TITLE
style: highlight reachable cards

### DIFF
--- a/css/cards.css
+++ b/css/cards.css
@@ -36,6 +36,8 @@
 /* Alcance (células verdes) */
 .card.reachable {
   cursor: pointer;
+  background: rgba(16, 185, 129, 0.3);
+  background-image: none;
 }
 
 .card.path {


### PR DESCRIPTION
## Summary
- make reachable cards use same green highlight as path cells

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68aa3f6388c0832eb670faeb66baa6a1