### PR TITLE
Reduce unit movement to two points

### DIFF
--- a/js/ui.js
+++ b/js/ui.js
@@ -144,7 +144,7 @@ export function gameOver(result) {
 
 export function passTurn() {
   const finished = getActive();
-  finished.pm = 3;
+  finished.pm = 2;
   finished.pa = 6;
   const next = finished.id === 'blue' ? 'red' : 'blue';
   setActiveId(next);

--- a/js/units.js
+++ b/js/units.js
@@ -9,7 +9,7 @@ export const units = {
     id: 'blue',
     maxPv: 10,
     pv: 10,
-    pm: 3,
+    pm: 2,
     pa: 6,
     pos: { row: 5, col: 3 },
     x: 0,
@@ -21,7 +21,7 @@ export const units = {
     id: 'red',
     maxPv: 10,
     pv: 10,
-    pm: 3,
+    pm: 2,
     pa: 6,
     pos: { row: 0, col: 0 },
     x: 0,
@@ -55,12 +55,12 @@ export function resetUnits() {
   units.blue.pos = { row: 5, col: 3 };
   units.blue.maxPv = 10;
   units.blue.pv = units.blue.maxPv;
-  units.blue.pm = 3;
+  units.blue.pm = 2;
   units.blue.pa = 6;
   units.red.pos = { row: 0, col: 0 };
   units.red.maxPv = 10;
   units.red.pv = units.red.maxPv;
-  units.red.pm = 3;
+  units.red.pm = 2;
   units.red.pa = 6;
   Object.values(units).forEach(u => {
     u.el?.remove();

--- a/tests/ui.test.js
+++ b/tests/ui.test.js
@@ -126,7 +126,7 @@ describe('addItemCard', () => {
     units.blue.maxPv = 10;
     units.blue.pv = 10;
     units.blue.pa = 6;
-    units.blue.pm = 3;
+    units.blue.pm = 2;
   });
 
   test('using heal item subtracts PA cost once', () => {

--- a/tests/units.test.js
+++ b/tests/units.test.js
@@ -51,7 +51,7 @@ describe('units module', () => {
       .filter(i => i !== null)
       .sort((a, b) => a - b);
 
-    expect(reachable).toEqual([11, 14, 15, 17, 18, 19, 20, 21, 22]);
+    expect(reachable).toEqual([15, 18, 19, 21, 22]);
   });
 
   test('showSocoAlcance marks adjacent tiles as attackable', () => {


### PR DESCRIPTION
## Summary
- Lower default and reset PM from 3 to 2 in unit handling
- Ensure turn passing restores two PM
- Update tests to align with new movement limits

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68aa3f43bb74832e979428d70d3989c9