### PR TITLE
Ajusta testes para alcance de movimento 2

### DIFF
--- a/tests/moveUnitAlongPath.test.js
+++ b/tests/moveUnitAlongPath.test.js
@@ -52,7 +52,7 @@ test('moveUnitAlongPath snaps unit to destination without extra transition', asy
     { row: 1, col: 2 },
   ];
 
-  const promise = moveUnitAlongPath(unit, path, 1);
+  const promise = moveUnitAlongPath(unit, path, 2);
   // simulate end of movement transition
   el.dispatchEvent(new Event('transitionend'));
   await promise;

--- a/tests/pathfinding.test.js
+++ b/tests/pathfinding.test.js
@@ -21,21 +21,20 @@ describe('computeReachable', () => {
 describe('buildPath', () => {
   test('reconstructs shortest path', () => {
     const start = { row: 0, col: 0 };
-    const dest = { row: 2, col: 1 };
-    const dist = computeReachable(start, 4, () => true);
+    const dest = { row: 1, col: 1 };
+    const dist = computeReachable(start, 2, () => true);
     const path = buildPath(start, dest, dist, () => true);
     expect(path).toEqual([
       { row: 0, col: 0 },
       { row: 0, col: 1 },
       { row: 1, col: 1 },
-      { row: 2, col: 1 },
     ]);
   });
 
   test('returns null when target is unreachable', () => {
     const start = { row: 0, col: 0 };
     const isAllowed = (r, c) => !(r === 0 && c === 1);
-    const dist = computeReachable(start, 3, isAllowed);
+    const dist = computeReachable(start, 2, isAllowed);
     const dest = { row: 0, col: 2 };
     const path = buildPath(start, dest, dist, isAllowed);
     expect(path).toBeNull();


### PR DESCRIPTION
## Summary
- Atualiza testes de pathfinding para usar PM 2 e ajustar caminho esperado
- Altera teste de movimento para consumir 2 PM

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68aa477c1be0832e8c9b14e51a93d004