### PR TITLE
Clear movement highlight when selecting attacks or items

### DIFF
--- a/js/ui.js
+++ b/js/ui.js
@@ -19,6 +19,10 @@ export const uiState = {
   selectedItem: null,
 };
 
+export function isMovementHighlightAllowed() {
+  return !uiState.socoSelecionado && !uiState.selectedItem;
+}
+
 function showSocoAlcance() {
   const active = getActive();
   showSocoAlcanceUnits(active);
@@ -202,6 +206,7 @@ export function initUI() {
       uiState.selectedItem?.slot?.classList.remove('is-selected');
       uiState.selectedItem = null;
       clearItemAlcance();
+      clearReachable();
       showSocoAlcance();
     } else {
       clearSocoAlcance();
@@ -303,6 +308,7 @@ export function addItemCard(item, onComplete = () => {}) {
           uiState.socoSelecionado = false;
           uiState.socoSlot?.classList.remove('is-selected');
           clearSocoAlcance();
+          clearReachable();
           uiState.selectedItem = { item, card, slot };
           slot.classList.add('is-selected');
           showItemAlcance(item);

--- a/js/units.js
+++ b/js/units.js
@@ -1,5 +1,6 @@
 import { ROWS, COLS, rowColToIndex, isInside } from './board-utils.js';
 import { computeReachable, buildPath } from './pathfinding.js';
+import { isMovementHighlightAllowed } from './ui.js';
 
 let cards = [];
 let board = null;
@@ -67,6 +68,7 @@ export function resetUnits() {
     u.el = createUnitEl(u.id);
     u.el.addEventListener('mouseenter', () => {
       if (getActive().id !== u.id) return;
+      if (!isMovementHighlightAllowed()) return;
       showReachableFor(u);
     });
   });


### PR DESCRIPTION
## Summary
- Export a helper to check if movement highlighting is allowed
- Clear movement highlight when selecting punch or item cards
- Skip hover-based movement highlight while an attack or item is selected

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68aa4701bb3c832ea1bf81d3d0e78094